### PR TITLE
Upgrade Memoist and cleanup Robucop minor failures

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/google/google-auth-library-ruby'
   s.summary       = 'Google Auth Library for Ruby'
   s.license       = 'Apache-2.0'
-  s.description   = <<-eos
+  s.description   = <<-DESCRIPTION
    Allows simple authorization for accessing Google APIs.
    Provide support for Application Default Credentials, as described at
    https://developers.google.com/accounts/docs/application-default-credentials
-  eos
+  DESCRIPTION
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.12'
   s.add_dependency 'jwt', '>= 1.4', '< 3.0'
-  s.add_dependency 'memoist', '~> 0.12'
+  s.add_dependency 'memoist', '~> 0.16'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'os', '>= 0.9', '< 2.0'
   s.add_dependency 'signet', '~> 0.7'

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -35,16 +35,16 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NO_METADATA_SERVER_ERROR = <<END.freeze
+    NO_METADATA_SERVER_ERROR = <<ERROR.freeze
 Error code 404 trying to get security access token
 from Compute Engine metadata for the default service account. This
 may be because the virtual machine instance does not have permission
 scopes specified.
-END
-    UNEXPECTED_ERROR_SUFFIX = <<END.freeze
+ERROR
+    UNEXPECTED_ERROR_SUFFIX = <<ERROR.freeze
 trying to get security access token from Compute Engine metadata for
 the default service account
-END
+ERROR
 
     # Extends Signet::OAuth2::Client so that the auth token is obtained from
     # the GCE metadata server.


### PR DESCRIPTION
I work on a project that had the following error from Google Auth:

```
NoMethodError: undefined method `all_memoized_structs' for Class:Class
/gems/memoist-0.14.0/lib/memoist.rb:67 in memoized_structs
/gems/memoist-0.14.0/lib/memoist.rb:84 in flush_cache
/gems/memoist-0.14.0/lib/memoist.rb:63 in unmemoize_all
/gems/googleauth-0.6.6/lib/googleauth/application_default.rb:63 in get_application_default
```

We have upgraded Memoist to 0.16.0 to include the fix for https://github.com/matthewrudy/memoist/issues/63. This branch changes theGoogle Auth dependency to the upgraded version to avoid this for all other users.