### PR TITLE
Load project id from environment variables, service accounts, and cloud sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0 (2018/10/23)
+
+* Add project_id instance variable to UserRefreshCredentials, ServiceAccountCredentials, and Credentials.
+
 ## 0.6.7 (2018/10/16)
 
 * Update memoist dependency to ~> 0.16.

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -62,7 +62,7 @@ module Google
         @project_id = options['project_id'] || options['project']
         if keyfile.is_a? Signet::OAuth2::Client
           @client = keyfile
-          @project_id ||= keyfile.instance_variable_get :@project_id
+          @project_id ||= keyfile.project_id if keyfile.respond_to? :project_id
         elsif keyfile.is_a? Hash
           hash = stringify_hash_keys keyfile
           hash['scope'] ||= scope

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# rubocop:disable Metrics/AbcSize, MethodLength
+# rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, MethodLength
 
 require 'forwardable'
 require 'json'

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -46,7 +46,7 @@ module Google
       CLIENT_SECRET_VAR         = 'GOOGLE_CLIENT_SECRET'.freeze
       REFRESH_TOKEN_VAR         = 'GOOGLE_REFRESH_TOKEN'.freeze
       ACCOUNT_TYPE_VAR          = 'GOOGLE_ACCOUNT_TYPE'.freeze
-      PROJECT_ID_VAR            = 'GOOGLE_CLOUD_PROJECT'.freeze
+      PROJECT_ID_VAR            = 'GOOGLE_PROJECT_ID'.freeze
       GCLOUD_POSIX_COMMAND      = 'gcloud'.freeze
       GCLOUD_WINDOWS_COMMAND    = 'gcloud.cmd'.freeze
       GCLOUD_CONFIG_COMMAND     = 'config config-helper --format json'.freeze

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -39,14 +39,14 @@ module Google
     # credentials files on the file system.
     module CredentialsLoader
       extend Memoist
-      ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
-
-      PRIVATE_KEY_VAR = 'GOOGLE_PRIVATE_KEY'.freeze
-      CLIENT_EMAIL_VAR = 'GOOGLE_CLIENT_EMAIL'.freeze
-      CLIENT_ID_VAR = 'GOOGLE_CLIENT_ID'.freeze
+      ENV_VAR           = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
+      PRIVATE_KEY_VAR   = 'GOOGLE_PRIVATE_KEY'.freeze
+      CLIENT_EMAIL_VAR  = 'GOOGLE_CLIENT_EMAIL'.freeze
+      CLIENT_ID_VAR     = 'GOOGLE_CLIENT_ID'.freeze
       CLIENT_SECRET_VAR = 'GOOGLE_CLIENT_SECRET'.freeze
       REFRESH_TOKEN_VAR = 'GOOGLE_REFRESH_TOKEN'.freeze
-      ACCOUNT_TYPE_VAR = 'GOOGLE_ACCOUNT_TYPE'.freeze
+      ACCOUNT_TYPE_VAR  = 'GOOGLE_ACCOUNT_TYPE'.freeze
+      PROJECT_ID_VAR    = 'GOOGLE_CLOUD_PROJECT'.freeze
 
       CREDENTIALS_FILE_NAME = 'application_default_credentials.json'.freeze
       NOT_FOUND_ERROR =

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -39,14 +39,17 @@ module Google
     # credentials files on the file system.
     module CredentialsLoader
       extend Memoist
-      ENV_VAR           = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
-      PRIVATE_KEY_VAR   = 'GOOGLE_PRIVATE_KEY'.freeze
-      CLIENT_EMAIL_VAR  = 'GOOGLE_CLIENT_EMAIL'.freeze
-      CLIENT_ID_VAR     = 'GOOGLE_CLIENT_ID'.freeze
-      CLIENT_SECRET_VAR = 'GOOGLE_CLIENT_SECRET'.freeze
-      REFRESH_TOKEN_VAR = 'GOOGLE_REFRESH_TOKEN'.freeze
-      ACCOUNT_TYPE_VAR  = 'GOOGLE_ACCOUNT_TYPE'.freeze
-      PROJECT_ID_VAR    = 'GOOGLE_CLOUD_PROJECT'.freeze
+      ENV_VAR                   = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
+      PRIVATE_KEY_VAR           = 'GOOGLE_PRIVATE_KEY'.freeze
+      CLIENT_EMAIL_VAR          = 'GOOGLE_CLIENT_EMAIL'.freeze
+      CLIENT_ID_VAR             = 'GOOGLE_CLIENT_ID'.freeze
+      CLIENT_SECRET_VAR         = 'GOOGLE_CLIENT_SECRET'.freeze
+      REFRESH_TOKEN_VAR         = 'GOOGLE_REFRESH_TOKEN'.freeze
+      ACCOUNT_TYPE_VAR          = 'GOOGLE_ACCOUNT_TYPE'.freeze
+      PROJECT_ID_VAR            = 'GOOGLE_CLOUD_PROJECT'.freeze
+      GCLOUD_POSIX_COMMAND      = 'gcloud'.freeze
+      GCLOUD_WINDOWS_COMMAND    = 'gcloud.cmd'.freeze
+      GCLOUD_CONFIG_COMMAND     = 'config config-helper --format json'.freeze
 
       CREDENTIALS_FILE_NAME = 'application_default_credentials.json'.freeze
       NOT_FOUND_ERROR =
@@ -135,6 +138,15 @@ module Google
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
       module_function :warn_if_cloud_sdk_credentials
+
+      def load_gcloud_project_id
+        gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
+        gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
+        config = MultiJson.load(`#{gcloud} #{GCLOUD_CONFIG_COMMAND}`)
+        config['configuration']['properties']['core']['project']
+      rescue
+        nil
+      end
 
       private
 

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -145,7 +145,7 @@ module Google
         config = MultiJson.load(`#{gcloud} #{GCLOUD_CONFIG_COMMAND}`)
         config['configuration']['properties']['core']['project']
       rescue
-        nil
+        warn 'Unable to determine project id.'
       end
 
       private

--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -38,7 +38,8 @@ module Google
         json_key = MultiJson.load(json_key_io.read)
         raise 'missing client_email' unless json_key.key?('client_email')
         raise 'missing private_key' unless json_key.key?('private_key')
-        [json_key['private_key'], json_key['client_email']]
+        project_id = json_key['project_id']
+        [json_key['private_key'], json_key['client_email'], project_id]
       end
     end
   end

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -65,6 +65,7 @@ module Google
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
         end
+        project_id ||= self.class.load_gcloud_project_id
 
         new(token_credential_uri: TOKEN_CRED_URI,
             audience: TOKEN_CRED_URI,
@@ -84,8 +85,8 @@ module Google
       end
 
       def initialize(options = {})
-        super(options)
         @project_id = options[:project_id]
+        super(options)
       end
 
       # Extends the base class.
@@ -130,6 +131,7 @@ module Google
       EXPIRY = 60
       extend CredentialsLoader
       extend JsonKeyReader
+      attr_reader :project_id
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -155,6 +157,7 @@ module Google
           @issuer = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           @project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
         end
+        @project_id ||= self.class.load_gcloud_project_id
         @signing_key = OpenSSL::PKey::RSA.new(@private_key)
       end
 

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -62,13 +62,15 @@ module Google
         user_creds ||= {
           'client_id'     => ENV[CredentialsLoader::CLIENT_ID_VAR],
           'client_secret' => ENV[CredentialsLoader::CLIENT_SECRET_VAR],
-          'refresh_token' => ENV[CredentialsLoader::REFRESH_TOKEN_VAR]
+          'refresh_token' => ENV[CredentialsLoader::REFRESH_TOKEN_VAR],
+          'project_id'    => ENV[CredentialsLoader::PROJECT_ID_VAR]
         }
 
         new(token_credential_uri: TOKEN_CRED_URI,
             client_id: user_creds['client_id'],
             client_secret: user_creds['client_secret'],
             refresh_token: user_creds['refresh_token'],
+            project_id:    user_creds['project_id'],
             scope: scope)
       end
 
@@ -87,6 +89,8 @@ module Google
         options ||= {}
         options[:token_credential_uri] ||= TOKEN_CRED_URI
         options[:authorization_uri] ||= AUTHORIZATION_URI
+        @project_id = options[:project_id]
+        @project_id ||= self.class.load_gcloud_project_id
         super(options)
       end
 

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -50,6 +50,7 @@ module Google
       AUTHORIZATION_URI = 'https://accounts.google.com/o/oauth2/auth'.freeze
       REVOKE_TOKEN_URI = 'https://oauth2.googleapis.com/revoke'.freeze
       extend CredentialsLoader
+      attr_reader :project_id
 
       # Create a UserRefreshCredentials.
       #

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.6.7'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -40,7 +40,8 @@ describe Google::Auth::Credentials, :private do
       'private_key' => "-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAOyi0Hy1l4Ym2m2o71Q0TF4O9E81isZEsX0bb+Bqz1SXEaSxLiXM\nUZE8wu0eEXivXuZg6QVCW/5l+f2+9UPrdNUCAwEAAQJAJkqubA/Chj3RSL92guy3\nktzeodarLyw8gF8pOmpuRGSiEo/OLTeRUMKKD1/kX4f9sxf3qDhB4e7dulXR1co/\nIQIhAPx8kMW4XTTL6lJYd2K5GrH8uBMp8qL5ya3/XHrBgw3dAiEA7+3Iw3ULTn2I\n1J34WlJ2D5fbzMzB4FAHUNEV7Ys3f1kCIQDtUahCMChrl7+H5t9QS+xrn77lRGhs\nB50pjvy95WXpgQIhAI2joW6JzTfz8fAapb+kiJ/h9Vcs1ZN3iyoRlNFb61JZAiA8\nNy5NyNrMVwtB/lfJf1dAK/p/Bwd8LZLtgM6PapRfgw==\n-----END RSA PRIVATE KEY-----\n",
       'client_email' => 'credz-testabc1234567890xyz@developer.gserviceaccount.com',
       'client_id' => 'credz-testabc1234567890xyz.apps.googleusercontent.com',
-      'type' => 'service_account'
+      'type' => 'service_account',
+      'project_id' => 'a_project_id'
     }
   end
 
@@ -110,6 +111,7 @@ describe Google::Auth::Credentials, :private do
     creds = TestCredentials.default
     expect(creds).to be_a_kind_of(TestCredentials)
     expect(creds.client).to eq(mocked_signet)
+    expect(creds.project_id).to eq(default_keyfile_hash['project_id'])
   end
 
   it 'subclasses can use PATH_ENV_VARS to get keyfile path' do
@@ -142,6 +144,7 @@ describe Google::Auth::Credentials, :private do
     creds = TestCredentials.default
     expect(creds).to be_a_kind_of(TestCredentials)
     expect(creds.client).to eq(mocked_signet)
+    expect(creds.project_id).to eq(default_keyfile_hash['project_id'])
   end
 
   it 'subclasses can use JSON_ENV_VARS to get keyfile contents' do
@@ -173,6 +176,7 @@ describe Google::Auth::Credentials, :private do
     creds = TestCredentials.default
     expect(creds).to be_a_kind_of(TestCredentials)
     expect(creds.client).to eq(mocked_signet)
+    expect(creds.project_id).to eq(default_keyfile_hash['project_id'])
   end
 
   it 'subclasses can use DEFAULT_PATHS to get keyfile path' do
@@ -205,6 +209,7 @@ describe Google::Auth::Credentials, :private do
     creds = TestCredentials.default
     expect(creds).to be_a_kind_of(TestCredentials)
     expect(creds.client).to eq(mocked_signet)
+    expect(creds.project_id).to eq(default_keyfile_hash['project_id'])
   end
 
   it 'subclasses that find no matches default to Google::Auth.get_application_default' do
@@ -243,6 +248,7 @@ describe Google::Auth::Credentials, :private do
     creds = TestCredentials.default
     expect(creds).to be_a_kind_of(TestCredentials)
     expect(creds.client).to eq(mocked_signet)
+    expect(creds.project_id).to eq(default_keyfile_hash['project_id'])
   end
 
   it 'warns when cloud sdk credentials are used' do

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -174,7 +174,7 @@ describe '#get_application_default' do
       ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
       ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
       ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
-      allow(Google::Auth::CredentialsLoader).to receive(:load_gcloud_project_id).and_return(nil)
+      ENV[PROJECT_ID_VAR] = 'a_project_id'
       expect { Google::Auth.get_application_default @scope, options }.to output(
         Google::Auth::CredentialsLoader::CLOUD_SDK_CREDENTIALS_WARNING + "\n"
       ).to_stderr

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -261,6 +261,7 @@ describe '#get_application_default' do
     end
 
     it 'fails if env vars are set' do
+      ENV[ENV_VAR] = nil
       ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
       ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect do

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -35,6 +35,7 @@ require 'faraday'
 require 'fakefs/safe'
 require 'googleauth'
 require 'spec_helper'
+require 'os'
 
 describe '#get_application_default' do
   # Pass unique options each time to bypass memoization

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -174,6 +174,7 @@ describe '#get_application_default' do
       ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
       ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
       ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
+      allow(Google::Auth::CredentialsLoader).to receive(:load_gcloud_project_id).and_return(nil)
       expect { Google::Auth.get_application_default @scope, options }.to output(
         Google::Auth::CredentialsLoader::CLOUD_SDK_CREDENTIALS_WARNING + "\n"
       ).to_stderr

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -116,7 +116,8 @@ describe Google::Auth::ServiceAccountCredentials do
       private_key: @key.to_pem,
       client_email: client_email,
       client_id: 'app.apps.googleusercontent.com',
-      type: 'service_account'
+      type: 'service_account',
+      project_id: 'a_project_id'
     }
   end
 
@@ -249,6 +250,19 @@ describe Google::Auth::ServiceAccountCredentials do
         ENV['HOME'] = dir
         ENV['APPDATA'] = dir
         expect(@clz.from_well_known_path(@scope)).to_not be_nil
+      end
+    end
+
+    it 'successfully sets project_id when file is present' do
+      Dir.mktmpdir do |dir|
+        key_path = File.join(dir, '.config', @known_path)
+        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        FileUtils.mkdir_p(File.dirname(key_path))
+        File.write(key_path, cred_json_text)
+        ENV['HOME'] = dir
+        ENV['APPDATA'] = dir
+        credentials = @clz.from_well_known_path(@scope)
+        expect(credentials.project_id).to eq(cred_json[:project_id])
       end
     end
   end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -214,6 +214,15 @@ describe Google::Auth::ServiceAccountCredentials do
       expect(@clz.from_env(@scope)).to_not be_nil
     end
 
+    it 'sets project_id when the PROJECT_ID_VAR env var is set' do
+      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[PROJECT_ID_VAR] = cred_json[:project_id]
+      ENV[ENV_VAR] = nil
+      credentials = @clz.from_env(@scope)
+      expect(credentials.project_id).to eq(cred_json[:project_id])
+    end
+
     it 'succeeds when GOOGLE_PRIVATE_KEY is escaped' do
       escaped_key = cred_json[:private_key].gsub "\n", '\n'
       ENV[PRIVATE_KEY_VAR] = "\"#{escaped_key}\""
@@ -311,7 +320,8 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
       private_key: @key.to_pem,
       client_email: client_email,
       client_id: 'app.apps.googleusercontent.com',
-      type: 'service_account'
+      type: 'service_account',
+      project_id: 'a_project_id'
     }
   end
 
@@ -372,6 +382,16 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
       ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect(clz.from_env(@scope)).to_not be_nil
     end
+
+    it 'sets project_id when the PROJECT_ID_VAR env var is set' do
+      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[PROJECT_ID_VAR] = cred_json[:project_id]
+      ENV[ENV_VAR] = nil
+      credentials = clz.from_env(@scope)
+      expect(credentials).to_not be_nil
+      expect(credentials.project_id).to eq(cred_json[:project_id])
+    end
   end
 
   describe '#from_well_known_path' do
@@ -399,6 +419,19 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
         ENV['HOME'] = dir
         ENV['APPDATA'] = dir
         expect(clz.from_well_known_path).to_not be_nil
+      end
+    end
+
+    it 'successfully sets project_id when file is present' do
+      Dir.mktmpdir do |dir|
+        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
+        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        FileUtils.mkdir_p(File.dirname(key_path))
+        File.write(key_path, cred_json_text)
+        ENV['HOME'] = dir
+        ENV['APPDATA'] = dir
+        credentials = clz.from_well_known_path(@scope)
+        expect(credentials.project_id).to eq(cred_json[:project_id])
       end
     end
   end

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -140,6 +140,7 @@ describe Google::Auth::UserRefreshCredentials do
 
     it 'succeeds when GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and '\
       'GOOGLE_REFRESH_TOKEN env vars are valid' do
+      ENV[ENV_VAR] = nil
       ENV[CLIENT_ID_VAR] = cred_json[:client_id]
       ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
       ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]


### PR DESCRIPTION
https://github.com/googleapis/google-auth-library-ruby/issues/90
https://github.com/googleapis/google-cloud-ruby/issues/951
May be helpful for https://github.com/googleapis/google-cloud-ruby/issues/2013

The library will attempt to grab the project id in the following order
1) ENV['GOOGLE_APPLICATION_CREDENTIALS']
2) ENV['GOOGLE_CLOUD_PROJECT']
3) ~/.config/gcloud/application_default_credentials.json
4) System default path
5) gcloud config config-helper