### PR TITLE
Don't call Class.load_gcloud_project_id

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -65,7 +65,7 @@ module Google
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
         end
-        project_id ||= self.class.load_gcloud_project_id
+        project_id ||= load_gcloud_project_id
 
         new(token_credential_uri: TOKEN_CRED_URI,
             audience: TOKEN_CRED_URI,

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -38,15 +38,22 @@ require 'spec_helper'
 require 'os'
 
 describe '#get_application_default' do
+  CredentialsLoader = Google::Auth::CredentialsLoader
+
   # Pass unique options each time to bypass memoization
   let(:options) { |example| { dememoize: example } }
 
   before(:example) do
     @key = OpenSSL::PKey::RSA.new(2048)
-    @var_name = ENV_VAR
+    @var_name = CredentialsLoader::ENV_VAR
     @credential_vars = [
-      ENV_VAR, PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR, CLIENT_ID_VAR,
-      CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR, ACCOUNT_TYPE_VAR
+      CredentialsLoader::ENV_VAR,
+      CredentialsLoader::PRIVATE_KEY_VAR,
+      CredentialsLoader::CLIENT_EMAIL_VAR,
+      CredentialsLoader::CLIENT_ID_VAR,
+      CredentialsLoader::CLIENT_SECRET_VAR,
+      CredentialsLoader::REFRESH_TOKEN_VAR,
+      CredentialsLoader::ACCOUNT_TYPE_VAR
     ]
     @original_env_vals = {}
     @credential_vars.each { |var| @original_env_vals[var] = ENV[var] }
@@ -103,8 +110,8 @@ describe '#get_application_default' do
     it 'succeeds with default file without GOOGLE_APPLICATION_CREDENTIALS' do
       ENV.delete(@var_name) unless ENV[@var_name].nil?
       Dir.mktmpdir do |dir|
-        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, '.config', CredentialsLoader::WELL_KNOWN_PATH)
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -117,8 +124,8 @@ describe '#get_application_default' do
     it 'succeeds with default file without a scope' do
       ENV.delete(@var_name) unless ENV[@var_name].nil?
       Dir.mktmpdir do |dir|
-        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, '.config', CredentialsLoader::WELL_KNOWN_PATH)
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -145,7 +152,7 @@ describe '#get_application_default' do
       FakeFS do
         ENV['ProgramData'] = '/etc'
         prefix = OS.windows? ? '/etc/Google/Auth/' : '/etc/google/auth/'
-        key_path = File.join(prefix, CREDENTIALS_FILE_NAME)
+        key_path = File.join(prefix, CredentialsLoader::CREDENTIALS_FILE_NAME)
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         expect(Google::Auth.get_application_default(@scope, options))
@@ -156,25 +163,25 @@ describe '#get_application_default' do
 
     it 'succeeds if environment vars are valid' do
       ENV.delete(@var_name) unless ENV[@var_name].nil? # no env var
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
-      ENV[CLIENT_ID_VAR] = cred_json[:client_id]
-      ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
-      ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::CLIENT_ID_VAR] = cred_json[:client_id]
+      ENV[CredentialsLoader::CLIENT_SECRET_VAR] = cred_json[:client_secret]
+      ENV[CredentialsLoader::REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
       expect(Google::Auth.get_application_default(@scope, options))
         .to_not be_nil
     end
 
     it 'warns when using cloud sdk credentials' do
       ENV.delete(@var_name) unless ENV[@var_name].nil? # no env var
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
-      ENV[CLIENT_ID_VAR] = Google::Auth::CredentialsLoader::CLOUD_SDK_CLIENT_ID
-      ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
-      ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
-      ENV[PROJECT_ID_VAR] = 'a_project_id'
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::CLIENT_ID_VAR] = Google::Auth::CredentialsLoader::CLOUD_SDK_CLIENT_ID
+      ENV[CredentialsLoader::CLIENT_SECRET_VAR] = cred_json[:client_secret]
+      ENV[CredentialsLoader::REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::PROJECT_ID_VAR] = 'a_project_id'
       expect { Google::Auth.get_application_default @scope, options }.to output(
         Google::Auth::CredentialsLoader::CLOUD_SDK_CREDENTIALS_WARNING + "\n"
       ).to_stderr
@@ -249,8 +256,8 @@ describe '#get_application_default' do
     it 'fails if the well known file contains the creds' do
       ENV.delete(@var_name) unless ENV[@var_name].nil?
       Dir.mktmpdir do |dir|
-        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, '.config', CredentialsLoader::WELL_KNOWN_PATH)
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -262,9 +269,9 @@ describe '#get_application_default' do
     end
 
     it 'fails if env vars are set' do
-      ENV[ENV_VAR] = nil
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::ENV_VAR] = nil
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect do
         Google::Auth.get_application_default @scope, options
       end.to raise_error RuntimeError

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -42,8 +42,6 @@ require 'spec_helper'
 require 'tmpdir'
 require 'os'
 
-include Google::Auth::CredentialsLoader
-
 shared_examples 'jwt header auth' do
   context 'when jwt_aud_uri is present' do
     let(:test_uri) { 'https://www.googleapis.com/myservice' }
@@ -108,6 +106,7 @@ shared_examples 'jwt header auth' do
 end
 
 describe Google::Auth::ServiceAccountCredentials do
+  CredentialsLoader = Google::Auth::CredentialsLoader
   ServiceAccountCredentials = Google::Auth::ServiceAccountCredentials
   let(:client_email) { 'app@developer.gserviceaccount.com' }
   let(:cred_json) do
@@ -166,13 +165,16 @@ describe Google::Auth::ServiceAccountCredentials do
 
   describe '#from_env' do
     before(:example) do
-      @var_name = ENV_VAR
+      @var_name = CredentialsLoader::ENV_VAR
       @credential_vars = [
-        ENV_VAR, PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR, ACCOUNT_TYPE_VAR
+        CredentialsLoader::ENV_VAR,
+        CredentialsLoader::PRIVATE_KEY_VAR,
+        CredentialsLoader::CLIENT_EMAIL_VAR,
+        CredentialsLoader::ACCOUNT_TYPE_VAR
       ]
       @original_env_vals = {}
       @credential_vars.each { |var| @original_env_vals[var] = ENV[var] }
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
 
       @scope = 'https://www.googleapis.com/auth/userinfo.profile'
       @clz = ServiceAccountCredentials
@@ -209,24 +211,24 @@ describe Google::Auth::ServiceAccountCredentials do
 
     it 'succeeds when GOOGLE_PRIVATE_KEY and GOOGLE_CLIENT_EMAIL env vars are'\
       ' valid' do
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect(@clz.from_env(@scope)).to_not be_nil
     end
 
     it 'sets project_id when the PROJECT_ID_VAR env var is set' do
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
-      ENV[PROJECT_ID_VAR] = cred_json[:project_id]
-      ENV[ENV_VAR] = nil
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::PROJECT_ID_VAR] = cred_json[:project_id]
+      ENV[CredentialsLoader::ENV_VAR] = nil
       credentials = @clz.from_env(@scope)
       expect(credentials.project_id).to eq(cred_json[:project_id])
     end
 
     it 'succeeds when GOOGLE_PRIVATE_KEY is escaped' do
       escaped_key = cred_json[:private_key].gsub "\n", '\n'
-      ENV[PRIVATE_KEY_VAR] = "\"#{escaped_key}\""
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = "\"#{escaped_key}\""
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect(@clz.from_env(@scope)).to_not be_nil
     end
   end
@@ -236,7 +238,7 @@ describe Google::Auth::ServiceAccountCredentials do
       @home = ENV['HOME']
       @app_data = ENV['APPDATA']
       @scope = 'https://www.googleapis.com/auth/userinfo.profile'
-      @known_path = WELL_KNOWN_PATH
+      @known_path = CredentialsLoader::WELL_KNOWN_PATH
       @clz = ServiceAccountCredentials
     end
 
@@ -253,7 +255,7 @@ describe Google::Auth::ServiceAccountCredentials do
     it 'successfully loads the file when it is present' do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, '.config', @known_path)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -265,7 +267,7 @@ describe Google::Auth::ServiceAccountCredentials do
     it 'successfully sets project_id when file is present' do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, '.config', @known_path)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -281,7 +283,7 @@ describe Google::Auth::ServiceAccountCredentials do
       @scope = 'https://www.googleapis.com/auth/userinfo.profile'
       @program_data = ENV['ProgramData']
       @prefix = OS.windows? ? '/etc/Google/Auth/' : '/etc/google/auth/'
-      @path = File.join(@prefix, CREDENTIALS_FILE_NAME)
+      @path = File.join(@prefix, CredentialsLoader::CREDENTIALS_FILE_NAME)
       @clz = ServiceAccountCredentials
     end
 
@@ -338,13 +340,16 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
   describe '#from_env' do
     before(:example) do
-      @var_name = ENV_VAR
+      @var_name = CredentialsLoader::ENV_VAR
       @credential_vars = [
-        ENV_VAR, PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR, ACCOUNT_TYPE_VAR
+        CredentialsLoader::ENV_VAR,
+        CredentialsLoader::PRIVATE_KEY_VAR,
+        CredentialsLoader::CLIENT_EMAIL_VAR,
+        CredentialsLoader::ACCOUNT_TYPE_VAR
       ]
       @original_env_vals = {}
       @credential_vars.each { |var| @original_env_vals[var] = ENV[var] }
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
     end
 
     after(:example) do
@@ -378,16 +383,16 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
     it 'succeeds when GOOGLE_PRIVATE_KEY and GOOGLE_CLIENT_EMAIL env vars are'\
       ' valid' do
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect(clz.from_env(@scope)).to_not be_nil
     end
 
     it 'sets project_id when the PROJECT_ID_VAR env var is set' do
-      ENV[PRIVATE_KEY_VAR] = cred_json[:private_key]
-      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
-      ENV[PROJECT_ID_VAR] = cred_json[:project_id]
-      ENV[ENV_VAR] = nil
+      ENV[CredentialsLoader::PRIVATE_KEY_VAR] = cred_json[:private_key]
+      ENV[CredentialsLoader::CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      ENV[CredentialsLoader::PROJECT_ID_VAR] = cred_json[:project_id]
+      ENV[CredentialsLoader::ENV_VAR] = nil
       credentials = clz.from_env(@scope)
       expect(credentials).to_not be_nil
       expect(credentials.project_id).to eq(cred_json[:project_id])
@@ -412,8 +417,8 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
     it 'successfully loads the file when it is present' do
       Dir.mktmpdir do |dir|
-        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, '.config', CredentialsLoader::WELL_KNOWN_PATH)
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
@@ -424,8 +429,8 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
     it 'successfully sets project_id when file is present' do
       Dir.mktmpdir do |dir|
-        key_path = File.join(dir, '.config', WELL_KNOWN_PATH)
-        key_path = File.join(dir, WELL_KNOWN_PATH) if OS.windows?
+        key_path = File.join(dir, '.config', CredentialsLoader::WELL_KNOWN_PATH)
+        key_path = File.join(dir, CredentialsLoader::WELL_KNOWN_PATH) if OS.windows?
         FileUtils.mkdir_p(File.dirname(key_path))
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -42,9 +42,8 @@ require 'spec_helper'
 require 'tmpdir'
 require 'os'
 
-include Google::Auth::CredentialsLoader
-
 describe Google::Auth::UserRefreshCredentials do
+  CredentialsLoader = Google::Auth::CredentialsLoader
   UserRefreshCredentials = Google::Auth::UserRefreshCredentials
 
   let(:cred_json) do
@@ -85,10 +84,13 @@ describe Google::Auth::UserRefreshCredentials do
 
   describe '#from_env' do
     before(:example) do
-      @var_name = ENV_VAR
+      @var_name = CredentialsLoader::ENV_VAR
       @credential_vars = [
-        ENV_VAR, CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR,
-        ACCOUNT_TYPE_VAR
+        CredentialsLoader::ENV_VAR,
+        CredentialsLoader::CLIENT_ID_VAR,
+        CredentialsLoader::CLIENT_SECRET_VAR,
+        CredentialsLoader::REFRESH_TOKEN_VAR,
+        CredentialsLoader::ACCOUNT_TYPE_VAR
       ]
       @original_env_vals = {}
       @credential_vars.each { |var| @original_env_vals[var] = ENV[var] }
@@ -141,11 +143,11 @@ describe Google::Auth::UserRefreshCredentials do
 
     it 'succeeds when GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and '\
       'GOOGLE_REFRESH_TOKEN env vars are valid' do
-      ENV[ENV_VAR] = nil
-      ENV[CLIENT_ID_VAR] = cred_json[:client_id]
-      ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
-      ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::ENV_VAR] = nil
+      ENV[CredentialsLoader::CLIENT_ID_VAR] = cred_json[:client_id]
+      ENV[CredentialsLoader::CLIENT_SECRET_VAR] = cred_json[:client_secret]
+      ENV[CredentialsLoader::REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
       creds = @clz.from_env(@scope)
       expect(creds).to_not be_nil
       expect(creds.client_id).to eq(cred_json[:client_id])
@@ -154,12 +156,12 @@ describe Google::Auth::UserRefreshCredentials do
     end
 
     it 'sets project_id when the PROJECT_ID_VAR env var is set' do
-      ENV[ENV_VAR] = nil
-      ENV[CLIENT_ID_VAR] = cred_json[:client_id]
-      ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
-      ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
-      ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
-      ENV[PROJECT_ID_VAR] = @project_id
+      ENV[CredentialsLoader::ENV_VAR] = nil
+      ENV[CredentialsLoader::CLIENT_ID_VAR] = cred_json[:client_id]
+      ENV[CredentialsLoader::CLIENT_SECRET_VAR] = cred_json[:client_secret]
+      ENV[CredentialsLoader::REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
+      ENV[CredentialsLoader::ACCOUNT_TYPE_VAR] = cred_json[:type]
+      ENV[CredentialsLoader::PROJECT_ID_VAR] = @project_id
       creds = @clz.from_env(@scope)
       expect(creds.project_id).to eq(@project_id)
     end
@@ -170,7 +172,7 @@ describe Google::Auth::UserRefreshCredentials do
       @home = ENV['HOME']
       @app_data = ENV['APPDATA']
       @scope = 'https://www.googleapis.com/auth/userinfo.profile'
-      @known_path = WELL_KNOWN_PATH
+      @known_path = CredentialsLoader::WELL_KNOWN_PATH
       @clz = UserRefreshCredentials
     end
 
@@ -220,7 +222,7 @@ describe Google::Auth::UserRefreshCredentials do
         File.write(key_path, cred_json_text)
         ENV['HOME'] = dir
         ENV['APPDATA'] = dir
-        ENV[PROJECT_ID_VAR] = nil
+        ENV[CredentialsLoader::PROJECT_ID_VAR] = nil
         expect(@clz).to receive(:load_gcloud_project_id).with(no_args)
         @clz.from_well_known_path(@scope)
       end
@@ -231,7 +233,7 @@ describe Google::Auth::UserRefreshCredentials do
     before(:example) do
       @scope = 'https://www.googleapis.com/auth/userinfo.profile'
       @prefix = OS.windows? ? '/etc/Google/Auth/' : '/etc/google/auth/'
-      @path = File.join(@prefix, CREDENTIALS_FILE_NAME)
+      @path = File.join(@prefix, CredentialsLoader::CREDENTIALS_FILE_NAME)
       @program_data = ENV['ProgramData']
       @clz = UserRefreshCredentials
     end


### PR DESCRIPTION
Why
----

Closes #168 

The `Google::Auth::ServiceAccountCredentials.make_creds` calls `Class.load_gcloud_project_id`.
But the `Class` doesn't respond to `load_gcloud_project_id`.
It should call `Google::Auth::ServiceAccountCredentials.load_gcloud_project_id`.

How
----

- Fix spec files to test real behavior
- Fix to call `Google::Auth::ServiceAccountCredentials.load_gcloud_project_id`

Verify
----

- Pass rspec