### PR TITLE
Remove warning while looking up project_id

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -139,13 +139,14 @@ module Google
       end
       module_function :warn_if_cloud_sdk_credentials
 
+      # Finds project_id from gcloud CLI configuration
       def load_gcloud_project_id
         gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
         gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
         config = MultiJson.load(`#{gcloud} #{GCLOUD_CONFIG_COMMAND}`)
         config['configuration']['properties']['core']['project']
       rescue
-        warn 'Unable to determine project id.'
+        nil
       end
       module_function :load_gcloud_project_id
 


### PR DESCRIPTION
Remove the warning, as it is not necessary.

[refs googleapis/google-auth-library-ruby#90] [refs googleapis/google-api-ruby-client#750]