### PR TITLE
Support configuration of the connection object used to fetch tokens

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ Metrics/CyclomaticComplexity:
   Max: 8
 Metrics/MethodLength:
   Max: 20
+Metrics/ModuleLength:
+  Max: 150
 Metrics/ClassLength:
   Enabled: false
 Layout/IndentHeredoc:

--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -52,11 +52,21 @@ ERROR_MESSAGE
     # scope is ignored.
     #
     # @param scope [string|array|nil] the scope(s) to access
-    # @param options [hash] allows override of the connection being used
-    def get_application_default(scope = nil, options = {})
-      creds = DefaultCredentials.from_env(scope) ||
-              DefaultCredentials.from_well_known_path(scope) ||
-              DefaultCredentials.from_system_default_path(scope)
+    # @param options [Hash] Connection options. These may be used to configure
+    #     the `Faraday::Connection` used for outgoing HTTP requests. For
+    #     example, if a connection proxy must be used in the current network,
+    #     you may provide a connection with with the needed proxy options.
+    #     The following keys are recognized:
+    #     * `:default_connection` The connection object to use for token refresh
+    #       requests.
+    #     * `:connection_builder` A `Proc` that creates and returns a connection
+    #       to use for token refresh requests.
+    #     * `:connection` The connection to use to determine whether GCE
+    #       metadata credentials are available.
+      def get_application_default(scope = nil, options = {})
+      creds = DefaultCredentials.from_env(scope, options) ||
+              DefaultCredentials.from_well_known_path(scope, options) ||
+              DefaultCredentials.from_system_default_path(scope, options)
       return creds unless creds.nil?
       unless GCECredentials.on_gce?(options)
         # Clear cache of the result of GCECredentials.on_gce?

--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -57,13 +57,13 @@ ERROR_MESSAGE
     #     example, if a connection proxy must be used in the current network,
     #     you may provide a connection with with the needed proxy options.
     #     The following keys are recognized:
-    #     * `:default_connection` The connection object to use for token refresh
-    #       requests.
-    #     * `:connection_builder` A `Proc` that creates and returns a connection
-    #       to use for token refresh requests.
+    #     * `:default_connection` The connection object to use for token
+    #       refresh requests.
+    #     * `:connection_builder` A `Proc` that creates and returns a
+    #       connection to use for token refresh requests.
     #     * `:connection` The connection to use to determine whether GCE
     #       metadata credentials are available.
-      def get_application_default(scope = nil, options = {})
+    def get_application_default(scope = nil, options = {})
       creds = DefaultCredentials.from_env(scope, options) ||
               DefaultCredentials.from_well_known_path(scope, options) ||
               DefaultCredentials.from_system_default_path(scope, options)

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -87,10 +87,8 @@ ERROR
       # fetched.
       def fetch_access_token(options = {})
         c = options[:connection] || Faraday.default_connection
-        c.headers = { 'Metadata-Flavor' => 'Google' }
-
         retry_with_error do
-          resp = c.get(COMPUTE_AUTH_TOKEN_URI)
+          resp = c.get(COMPUTE_AUTH_TOKEN_URI, nil, { 'Metadata-Flavor' => 'Google' })
           case resp.status
           when 200
             Signet::OAuth2.parse_credentials(resp.body,

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -88,7 +88,8 @@ ERROR
       def fetch_access_token(options = {})
         c = options[:connection] || Faraday.default_connection
         retry_with_error do
-          resp = c.get(COMPUTE_AUTH_TOKEN_URI, nil, { 'Metadata-Flavor' => 'Google' })
+          headers = { 'Metadata-Flavor' => 'Google' }
+          resp = c.get(COMPUTE_AUTH_TOKEN_URI, nil, headers)
           case resp.status
           when 200
             Signet::OAuth2.parse_credentials(resp.body,

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -163,7 +163,7 @@ module Google
       def init_client(keyfile, connection_options = {})
         client_opts = client_options keyfile
         Signet::OAuth2::Client.new(client_opts)
-          .configure_connection(connection_options)
+                              .configure_connection(connection_options)
       end
 
       # returns a new Hash with string keys instead of symbol keys.

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -182,7 +182,7 @@ module Google
 
       private
 
-      def interpret_options scope, options
+      def interpret_options(scope, options)
         if scope.is_a? Hash
           options = scope
           scope = nil

--- a/lib/googleauth/default_credentials.rb
+++ b/lib/googleauth/default_credentials.rb
@@ -46,16 +46,16 @@ module Google
       # override CredentialsLoader#make_creds to use the class determined by
       # loading the json.
       def self.make_creds(options = {})
-        json_key_io, scope = options.values_at(:json_key_io, :scope)
+        json_key_io = options[:json_key_io]
         if json_key_io
           json_key, clz = determine_creds_class(json_key_io)
           warn_if_cloud_sdk_credentials json_key['client_id']
-          clz.make_creds(json_key_io: StringIO.new(MultiJson.dump(json_key)),
-                         scope: scope)
+          io = StringIO.new(MultiJson.dump(json_key))
+          clz.make_creds(options.merge(json_key_io: io))
         else
           warn_if_cloud_sdk_credentials ENV[CredentialsLoader::CLIENT_ID_VAR]
           clz = read_creds
-          clz.make_creds(scope: scope)
+          clz.make_creds(options)
         end
       end
 

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -73,7 +73,7 @@ module Google
             issuer: client_email,
             signing_key: OpenSSL::PKey::RSA.new(private_key),
             project_id: project_id)
-            .configure_connection(options)
+          .configure_connection(options)
       end
 
       # Handles certain escape sequences that sometimes appear in input.

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -73,6 +73,7 @@ module Google
             issuer: client_email,
             signing_key: OpenSSL::PKey::RSA.new(private_key),
             project_id: project_id)
+            .configure_connection(options)
       end
 
       # Handles certain escape sequences that sometimes appear in input.

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -38,8 +38,9 @@ module Signet
     # This reopens Client to add #apply and #apply! methods which update a
     # hash with the fetched authentication token.
     class Client
-      def configure_connection options
-        @connection_info = options[:connection_builder] || options[:default_connection]
+      def configure_connection(options)
+        @connection_info =
+          options[:connection_builder] || options[:default_connection]
         self
       end
 

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -38,6 +38,11 @@ module Signet
     # This reopens Client to add #apply and #apply! methods which update a
     # hash with the fetched authentication token.
     class Client
+      def configure_connection options
+        @connection_info = options[:connection_builder] || options[:default_connection]
+        self
+      end
+
       # Updates a_hash updated with the authentication token
       def apply!(a_hash, opts = {})
         # fetch the access token there is currently not one, or if the client
@@ -66,6 +71,10 @@ module Signet
 
       alias orig_fetch_access_token! fetch_access_token!
       def fetch_access_token!(options = {})
+        unless options[:connection]
+          connection = build_default_connection
+          options = options.merge(connection: connection) if connection
+        end
         info = orig_fetch_access_token!(options)
         notify_refresh_listeners
         info
@@ -75,6 +84,16 @@ module Signet
         listeners = @refresh_listeners || []
         listeners.each do |block|
           block.call(self)
+        end
+      end
+
+      def build_default_connection
+        if !defined?(@connection_info)
+          nil
+        elsif @connection_info.respond_to? :call
+          @connection_info.call
+        else
+          @connection_info
         end
       end
 

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -72,6 +72,7 @@ module Google
             refresh_token: user_creds['refresh_token'],
             project_id:    user_creds['project_id'],
             scope: scope)
+          .configure_connection(options)
       end
 
       # Reads the client_id, client_secret and refresh_token fields from the

--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -47,6 +47,7 @@ describe Google::Auth::Credentials, :private do
 
   it 'uses a default scope' do
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -64,6 +65,7 @@ describe Google::Auth::Credentials, :private do
 
   it 'uses a custom scope' do
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -96,6 +98,7 @@ describe Google::Auth::Credentials, :private do
     allow(::File).to receive(:file?).with(TEST_PATH_ENV_VAL) { false }
 
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -129,6 +132,7 @@ describe Google::Auth::Credentials, :private do
     allow(::File).to receive(:read).with('/unknown/path/to/file.txt') { JSON.generate(default_keyfile_hash) }
 
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -161,6 +165,7 @@ describe Google::Auth::Credentials, :private do
     allow(::ENV).to receive(:[]).with('JSON_ENV_TEST') { JSON.generate(default_keyfile_hash) }
 
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -194,6 +199,7 @@ describe Google::Auth::Credentials, :private do
     allow(::File).to receive(:read).with('~/default/path/to/file.txt') { JSON.generate(default_keyfile_hash) }
 
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
@@ -226,6 +232,7 @@ describe Google::Auth::Credentials, :private do
     allow(::File).to receive(:file?).with('~/default/path/to/file.txt') { false }
 
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(mocked_signet).to receive(:client_id)
     allow(Google::Auth).to receive(:get_application_default) do |scope|
@@ -253,6 +260,7 @@ describe Google::Auth::Credentials, :private do
 
   it 'warns when cloud sdk credentials are used' do
     mocked_signet = double('Signet::OAuth2::Client')
+    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
     allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
     allow(Signet::OAuth2::Client).to receive(:new) do |options|
       mocked_signet

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -100,6 +100,19 @@ describe '#get_application_default' do
       end
     end
 
+    it "propagates default_connection option" do
+      Dir.mktmpdir do |dir|
+        key_path = File.join(dir, 'my_cert_file')
+        FileUtils.mkdir_p(File.dirname(key_path))
+        File.write(key_path, cred_json_text)
+        ENV[@var_name] = key_path
+        connection = Faraday.new(headers: {"User-Agent" => "hello"})
+        opts = options.merge(default_connection: connection)
+        creds = Google::Auth.get_application_default(@scope, opts)
+        expect(creds.build_default_connection).to be connection
+      end
+    end
+
     it 'succeeds with default file without GOOGLE_APPLICATION_CREDENTIALS' do
       ENV.delete(@var_name) unless ENV[@var_name].nil?
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
The various `make_creds` and `from_*` methods that create credentials objects now recognize two more options:
* **:default_connection** The `Faraday::Connection` to use when making calls to refresh tokens.
* **:connection_builder** A `Proc` that is called when a token refresh needs to be done. Should return a `Faraday::Connection`.

These may be used, for example, to configure the connection suitably to connect through a proxy.

Fixes #131 