### PR TITLE
check if gcloud command exists before calling it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,4 +25,5 @@ Style/PercentLiteralDelimiters: # Contradicting rule
   Enabled: false
 Style/SymbolArray: # Undefined syntax in Ruby 1.9.3
   Enabled: false
-
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in googleauth.gemspec
 gemspec
 
 group :development do
-  gem 'bundler', '>= 1.9'
-  gem 'coveralls', '~> 0.7'
-  gem 'fakefs', '~> 0.6'
-  gem 'fakeredis', '~> 0.5'
-  gem 'logging', '~> 2.0'
-  gem 'rack-test', '~> 0.6'
-  gem 'rake', '~> 10.0'
-  gem 'redis', '~> 3.2'
-  gem 'rspec', '~> 3.0'
-  gem 'rubocop', '>= 0.41', '< 0.50'
-  gem 'simplecov', '~> 0.9'
-  gem 'sinatra'
-  gem 'webmock', '~> 1.21'
+  gem "bundler", ">= 1.9"
+  gem "coveralls", "~> 0.7"
+  gem "fakefs", "~> 0.6"
+  gem "fakeredis", "~> 0.5"
+  gem "logging", "~> 2.0"
+  gem "rack-test", "~> 0.6"
+  gem "rake", "~> 10.0"
+  gem "redis", "~> 3.2"
+  gem "rspec", "~> 3.0"
+  gem "rubocop", ">= 0.41", "< 0.50"
+  gem "simplecov", "~> 0.9"
+  gem "sinatra"
+  gem "webmock", "~> 1.21"
 end
 
 platforms :jruby do

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,15 @@
 # -*- ruby -*-
-require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
-require 'bundler/gem_tasks'
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
+require "bundler/gem_tasks"
 
-desc 'Run Rubocop to check for style violations'
+desc "Run Rubocop to check for style violations"
 RuboCop::RakeTask.new
 
-desc 'Run rake task'
+desc "Run rake task"
 RSpec::Core::RakeTask.new(:spec)
 
-desc 'Does rubocop lint and runs the specs'
+desc "Does rubocop lint and runs the specs"
 task all: [:rubocop, :spec]
 
 task default: :all

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -1,17 +1,17 @@
 # -*- ruby -*-
 # encoding: utf-8
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
-require 'googleauth/version'
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+require "googleauth/version"
 
 Gem::Specification.new do |s|
-  s.name          = 'googleauth'
+  s.name          = "googleauth"
   s.version       = Google::Auth::VERSION
-  s.authors       = ['Tim Emiola']
-  s.email         = 'temiola@google.com'
-  s.homepage      = 'https://github.com/google/google-auth-library-ruby'
-  s.summary       = 'Google Auth Library for Ruby'
-  s.license       = 'Apache-2.0'
+  s.authors       = ["Tim Emiola"]
+  s.email         = "temiola@google.com"
+  s.homepage      = "https://github.com/google/google-auth-library-ruby"
+  s.summary       = "Google Auth Library for Ruby"
+  s.license       = "Apache-2.0"
   s.description   = <<-DESCRIPTION
    Allows simple authorization for accessing Google APIs.
    Provide support for Application Default Credentials, as described at
@@ -23,13 +23,13 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*.rb`.split("\n").map do |f|
     File.basename(f)
   end
-  s.require_paths = ['lib']
+  s.require_paths = ["lib"]
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'faraday', '~> 0.12'
-  s.add_dependency 'jwt', '>= 1.4', '< 3.0'
-  s.add_dependency 'memoist', '~> 0.16'
-  s.add_dependency 'multi_json', '~> 1.11'
-  s.add_dependency 'os', '>= 0.9', '< 2.0'
-  s.add_dependency 'signet', '~> 0.7'
+  s.add_dependency "faraday", "~> 0.12"
+  s.add_dependency "jwt", ">= 1.4", "< 3.0"
+  s.add_dependency "memoist", "~> 0.16"
+  s.add_dependency "multi_json", "~> 1.11"
+  s.add_dependency "os", ">= 0.9", "< 2.0"
+  s.add_dependency "signet", "~> 0.7"
 end

--- a/lib/googleauth.rb
+++ b/lib/googleauth.rb
@@ -27,9 +27,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/application_default'
-require 'googleauth/client_id'
-require 'googleauth/credentials'
-require 'googleauth/default_credentials'
-require 'googleauth/user_authorizer'
-require 'googleauth/web_user_authorizer'
+require "googleauth/application_default"
+require "googleauth/client_id"
+require "googleauth/credentials"
+require "googleauth/default_credentials"
+require "googleauth/user_authorizer"
+require "googleauth/web_user_authorizer"

--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -27,8 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/compute_engine'
-require 'googleauth/default_credentials'
+require "googleauth/compute_engine"
+require "googleauth/default_credentials"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization

--- a/lib/googleauth/client_id.rb
+++ b/lib/googleauth/client_id.rb
@@ -27,18 +27,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'multi_json'
-require 'googleauth/credentials_loader'
+require "multi_json"
+require "googleauth/credentials_loader"
 
 module Google
   module Auth
     # Representation of an application's identity for user authorization
     # flows.
     class ClientId
-      INSTALLED_APP = 'installed'.freeze
-      WEB_APP = 'web'.freeze
-      CLIENT_ID = 'client_id'.freeze
-      CLIENT_SECRET = 'client_secret'.freeze
+      INSTALLED_APP = "installed".freeze
+      WEB_APP = "web".freeze
+      CLIENT_ID = "client_id".freeze
+      CLIENT_SECRET = "client_secret".freeze
       MISSING_TOP_LEVEL_ELEMENT_ERROR =
         "Expected top level property 'installed' or 'web' to be present.".freeze
 
@@ -65,8 +65,8 @@ module Google
       #       `client_secrets.json` files.
       def initialize(id, secret)
         CredentialsLoader.warn_if_cloud_sdk_credentials id
-        raise 'Client id can not be nil' if id.nil?
-        raise 'Client secret can not be nil' if secret.nil?
+        raise "Client id can not be nil" if id.nil?
+        raise "Client secret can not be nil" if secret.nil?
         @id = id
         @secret = secret
       end
@@ -78,7 +78,7 @@ module Google
       #  Path of file to read from
       # @return [Google::Auth::ClientID]
       def self.from_file(file)
-        raise 'File can not be nil.' if file.nil?
+        raise "File can not be nil." if file.nil?
         File.open(file.to_s) do |f|
           json = f.read
           config = MultiJson.load json
@@ -94,7 +94,7 @@ module Google
       #  Parsed contents of the JSON file
       # @return [Google::Auth::ClientID]
       def self.from_hash(config)
-        raise 'Hash can not be nil.' if config.nil?
+        raise "Hash can not be nil." if config.nil?
         raw_detail = config[INSTALLED_APP] || config[WEB_APP]
         raise MISSING_TOP_LEVEL_ELEMENT_ERROR if raw_detail.nil?
         ClientId.new(raw_detail[CLIENT_ID], raw_detail[CLIENT_SECRET])

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -27,9 +27,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'faraday'
-require 'googleauth/signet'
-require 'memoist'
+require "faraday"
+require "googleauth/signet"
+require "memoist"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -51,9 +51,9 @@ ERROR
     class GCECredentials < Signet::OAuth2::Client
       # The IP Address is used in the URIs to speed up failures on non-GCE
       # systems.
-      COMPUTE_AUTH_TOKEN_URI = 'http://169.254.169.254/computeMetadata/v1/'\
-      'instance/service-accounts/default/token'.freeze
-      COMPUTE_CHECK_URI = 'http://169.254.169.254'.freeze
+      COMPUTE_AUTH_TOKEN_URI = "http://169.254.169.254/computeMetadata/v1/"\
+      "instance/service-accounts/default/token".freeze
+      COMPUTE_CHECK_URI = "http://169.254.169.254".freeze
 
       class << self
         extend Memoist
@@ -74,8 +74,8 @@ ERROR
             req.options.timeout = 0.1
           end
           return false unless resp.status == 200
-          return false unless resp.headers.key?('Metadata-Flavor')
-          return resp.headers['Metadata-Flavor'] == 'Google'
+          return false unless resp.headers.key?("Metadata-Flavor")
+          return resp.headers["Metadata-Flavor"] == "Google"
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
           return false
         end
@@ -88,12 +88,12 @@ ERROR
       def fetch_access_token(options = {})
         c = options[:connection] || Faraday.default_connection
         retry_with_error do
-          headers = { 'Metadata-Flavor' => 'Google' }
+          headers = { "Metadata-Flavor" => "Google" }
           resp = c.get(COMPUTE_AUTH_TOKEN_URI, nil, headers)
           case resp.status
           when 200
             Signet::OAuth2.parse_credentials(resp.body,
-                                             resp.headers['content-type'])
+                                             resp.headers["content-type"])
           when 404
             raise(Signet::AuthorizationError, NO_METADATA_SERVER_ERROR)
           else

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -29,19 +29,19 @@
 
 # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, MethodLength
 
-require 'forwardable'
-require 'json'
-require 'signet/oauth_2/client'
+require "forwardable"
+require "json"
+require "signet/oauth_2/client"
 
-require 'googleauth/credentials_loader'
+require "googleauth/credentials_loader"
 
 module Google
   module Auth
     # This class is intended to be inherited by API-specific classes
     # which overrides the SCOPE constant.
     class Credentials
-      TOKEN_CREDENTIAL_URI = 'https://oauth2.googleapis.com/token'.freeze
-      AUDIENCE = 'https://oauth2.googleapis.com/token'.freeze
+      TOKEN_CREDENTIAL_URI = "https://oauth2.googleapis.com/token".freeze
+      AUDIENCE = "https://oauth2.googleapis.com/token".freeze
       SCOPE = [].freeze
       PATH_ENV_VARS = [].freeze
       JSON_ENV_VARS = [].freeze
@@ -59,20 +59,20 @@ module Google
       def initialize(keyfile, options = {})
         scope = options[:scope]
         verify_keyfile_provided! keyfile
-        @project_id = options['project_id'] || options['project']
+        @project_id = options["project_id"] || options["project"]
         if keyfile.is_a? Signet::OAuth2::Client
           @client = keyfile
           @project_id ||= keyfile.project_id if keyfile.respond_to? :project_id
         elsif keyfile.is_a? Hash
           hash = stringify_hash_keys keyfile
-          hash['scope'] ||= scope
+          hash["scope"] ||= scope
           @client = init_client hash, options
-          @project_id ||= (hash['project_id'] || hash['project'])
+          @project_id ||= (hash["project_id"] || hash["project"])
         else
           verify_keyfile_exists! keyfile
           json = JSON.parse ::File.read(keyfile)
-          json['scope'] ||= scope
-          @project_id ||= (json['project_id'] || json['project'])
+          json["scope"] ||= scope
+          @project_id ||= (json["project_id"] || json["project"])
           @client = init_client json, options
         end
         CredentialsLoader.warn_if_cloud_sdk_credentials @client.client_id
@@ -150,7 +150,7 @@ module Google
       # Verify that the keyfile argument is provided.
       def verify_keyfile_provided!(keyfile)
         return unless keyfile.nil?
-        raise 'The keyfile passed to Google::Auth::Credentials.new was nil.'
+        raise "The keyfile passed to Google::Auth::Credentials.new was nil."
       end
 
       # Verify that the keyfile argument is a file.
@@ -173,16 +173,16 @@ module Google
 
       def client_options(options)
         # Keyfile options have higher priority over constructor defaults
-        options['token_credential_uri'] ||= self.class::TOKEN_CREDENTIAL_URI
-        options['audience'] ||= self.class::AUDIENCE
-        options['scope'] ||= self.class::SCOPE
+        options["token_credential_uri"] ||= self.class::TOKEN_CREDENTIAL_URI
+        options["audience"] ||= self.class::AUDIENCE
+        options["scope"] ||= self.class::SCOPE
 
         # client options for initializing signet client
-        { token_credential_uri: options['token_credential_uri'],
-          audience: options['audience'],
-          scope: Array(options['scope']),
-          issuer: options['client_email'],
-          signing_key: OpenSSL::PKey::RSA.new(options['private_key']) }
+        { token_credential_uri: options["token_credential_uri"],
+          audience: options["audience"],
+          scope: Array(options["scope"]),
+          issuer: options["client_email"],
+          signing_key: OpenSSL::PKey::RSA.new(options["private_key"]) }
       end
     end
   end

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -172,8 +172,13 @@ module Google
 
       # Finds project_id from gcloud CLI configuration
       def load_gcloud_project_id
-        gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
-        gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
+        if OS.windows?
+          gcloud = GCLOUD_WINDOWS_COMMAND
+          return nil if `where gcloud`.count("\\").zero?
+        else
+          gcloud = GCLOUD_POSIX_COMMAND
+          return nil if `which gcloud`.empty?
+        end
         config = MultiJson.load(`#{gcloud} #{GCLOUD_CONFIG_COMMAND}`)
         config['configuration']['properties']['core']['project']
       rescue

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -27,9 +27,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'memoist'
-require 'os'
-require 'rbconfig'
+require "memoist"
+require "os"
+require "rbconfig"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -39,37 +39,37 @@ module Google
     # credentials files on the file system.
     module CredentialsLoader
       extend Memoist
-      ENV_VAR                   = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
-      PRIVATE_KEY_VAR           = 'GOOGLE_PRIVATE_KEY'.freeze
-      CLIENT_EMAIL_VAR          = 'GOOGLE_CLIENT_EMAIL'.freeze
-      CLIENT_ID_VAR             = 'GOOGLE_CLIENT_ID'.freeze
-      CLIENT_SECRET_VAR         = 'GOOGLE_CLIENT_SECRET'.freeze
-      REFRESH_TOKEN_VAR         = 'GOOGLE_REFRESH_TOKEN'.freeze
-      ACCOUNT_TYPE_VAR          = 'GOOGLE_ACCOUNT_TYPE'.freeze
-      PROJECT_ID_VAR            = 'GOOGLE_PROJECT_ID'.freeze
-      GCLOUD_POSIX_COMMAND      = 'gcloud'.freeze
-      GCLOUD_WINDOWS_COMMAND    = 'gcloud.cmd'.freeze
-      GCLOUD_CONFIG_COMMAND     = 'config config-helper --format json'.freeze
+      ENV_VAR                   = "GOOGLE_APPLICATION_CREDENTIALS".freeze
+      PRIVATE_KEY_VAR           = "GOOGLE_PRIVATE_KEY".freeze
+      CLIENT_EMAIL_VAR          = "GOOGLE_CLIENT_EMAIL".freeze
+      CLIENT_ID_VAR             = "GOOGLE_CLIENT_ID".freeze
+      CLIENT_SECRET_VAR         = "GOOGLE_CLIENT_SECRET".freeze
+      REFRESH_TOKEN_VAR         = "GOOGLE_REFRESH_TOKEN".freeze
+      ACCOUNT_TYPE_VAR          = "GOOGLE_ACCOUNT_TYPE".freeze
+      PROJECT_ID_VAR            = "GOOGLE_PROJECT_ID".freeze
+      GCLOUD_POSIX_COMMAND      = "gcloud".freeze
+      GCLOUD_WINDOWS_COMMAND    = "gcloud.cmd".freeze
+      GCLOUD_CONFIG_COMMAND     = "config config-helper --format json".freeze
 
-      CREDENTIALS_FILE_NAME = 'application_default_credentials.json'.freeze
+      CREDENTIALS_FILE_NAME = "application_default_credentials.json".freeze
       NOT_FOUND_ERROR =
         "Unable to read the credential file specified by #{ENV_VAR}".freeze
       WELL_KNOWN_PATH = "gcloud/#{CREDENTIALS_FILE_NAME}".freeze
-      WELL_KNOWN_ERROR = 'Unable to read the default credential file'.freeze
+      WELL_KNOWN_ERROR = "Unable to read the default credential file".freeze
 
       SYSTEM_DEFAULT_ERROR =
-        'Unable to read the system default credential file'.freeze
+        "Unable to read the system default credential file".freeze
 
-      CLOUD_SDK_CLIENT_ID = '764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.app'\
-        's.googleusercontent.com'.freeze
+      CLOUD_SDK_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.app"\
+        "s.googleusercontent.com".freeze
 
-      CLOUD_SDK_CREDENTIALS_WARNING = 'Your application has authenticated '\
-        'using end user credentials from Google Cloud SDK. We recommend that '\
-        'most server applications use service accounts instead. If your '\
-        'application continues to use end user credentials from Cloud SDK, '\
+      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated "\
+        "using end user credentials from Google Cloud SDK. We recommend that "\
+        "most server applications use service accounts instead. If your "\
+        "application continues to use end user credentials from Cloud SDK, "\
         'you might receive a "quota exceeded" or "API not enabled" error. For'\
-        ' more information about service accounts, see '\
-        'https://cloud.google.com/docs/authentication/.'.freeze
+        " more information about service accounts, see "\
+        "https://cloud.google.com/docs/authentication/.".freeze
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -123,10 +123,10 @@ module Google
       #     * `:connection_builder` A `Proc` that returns a connection.
       def from_well_known_path(scope = nil, options = {})
         options = interpret_options scope, options
-        home_var = OS.windows? ? 'APPDATA' : 'HOME'
+        home_var = OS.windows? ? "APPDATA" : "HOME"
         base = WELL_KNOWN_PATH
-        root = ENV[home_var].nil? ? '' : ENV[home_var]
-        base = File.join('.config', base) unless OS.windows?
+        root = ENV[home_var].nil? ? "" : ENV[home_var]
+        base = File.join(".config", base) unless OS.windows?
         path = File.join(root, base)
         return nil unless File.exist?(path)
         File.open(path) do |f|
@@ -150,10 +150,10 @@ module Google
       def from_system_default_path(scope = nil, options = {})
         options = interpret_options scope, options
         if OS.windows?
-          return nil unless ENV['ProgramData']
-          prefix = File.join(ENV['ProgramData'], 'Google/Auth')
+          return nil unless ENV["ProgramData"]
+          prefix = File.join(ENV["ProgramData"], "Google/Auth")
         else
-          prefix = '/etc/google/auth/'
+          prefix = "/etc/google/auth/"
         end
         path = File.join(prefix, CREDENTIALS_FILE_NAME)
         return nil unless File.exist?(path)
@@ -180,7 +180,7 @@ module Google
           return nil if `which gcloud`.empty?
         end
         config = MultiJson.load(`#{gcloud} #{GCLOUD_CONFIG_COMMAND}`)
-        config['configuration']['properties']['core']['project']
+        config["configuration"]["properties"]["core"]["project"]
       rescue
         nil
       end

--- a/lib/googleauth/default_credentials.rb
+++ b/lib/googleauth/default_credentials.rb
@@ -27,12 +27,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'multi_json'
-require 'stringio'
+require "multi_json"
+require "stringio"
 
-require 'googleauth/credentials_loader'
-require 'googleauth/service_account'
-require 'googleauth/user_refresh'
+require "googleauth/credentials_loader"
+require "googleauth/service_account"
+require "googleauth/user_refresh"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -49,7 +49,7 @@ module Google
         json_key_io = options[:json_key_io]
         if json_key_io
           json_key, clz = determine_creds_class(json_key_io)
-          warn_if_cloud_sdk_credentials json_key['client_id']
+          warn_if_cloud_sdk_credentials json_key["client_id"]
           io = StringIO.new(MultiJson.dump(json_key))
           clz.make_creds(options.merge(json_key_io: io))
         else
@@ -64,9 +64,9 @@ module Google
         type = ENV[env_var]
         raise "#{env_var} is undefined in env" unless type
         case type
-        when 'service_account'
+        when "service_account"
           ServiceAccountCredentials
-        when 'authorized_user'
+        when "authorized_user"
           UserRefreshCredentials
         else
           raise "credentials type '#{type}' is not supported"
@@ -76,13 +76,13 @@ module Google
       # Reads the input json and determines which creds class to use.
       def self.determine_creds_class(json_key_io)
         json_key = MultiJson.load json_key_io.read
-        key = 'type'
+        key = "type"
         raise "the json is missing the '#{key}' field" unless json_key.key?(key)
         type = json_key[key]
         case type
-        when 'service_account'
+        when "service_account"
           [json_key, ServiceAccountCredentials]
-        when 'authorized_user'
+        when "authorized_user"
           [json_key, UserRefreshCredentials]
         else
           raise "credentials type '#{type}' is not supported"

--- a/lib/googleauth/iam.rb
+++ b/lib/googleauth/iam.rb
@@ -27,9 +27,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/signet'
-require 'googleauth/credentials_loader'
-require 'multi_json'
+require "googleauth/signet"
+require "googleauth/credentials_loader"
+require "multi_json"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -37,8 +37,8 @@ module Google
   module Auth
     # Authenticates requests using IAM credentials.
     class IAMCredentials
-      SELECTOR_KEY = 'x-goog-iam-authority-selector'.freeze
-      TOKEN_KEY = 'x-goog-iam-authorization-token'.freeze
+      SELECTOR_KEY = "x-goog-iam-authority-selector".freeze
+      TOKEN_KEY = "x-goog-iam-authorization-token".freeze
 
       # Initializes an IAMCredentials.
       #

--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -36,10 +36,10 @@ module Google
     module JsonKeyReader
       def read_json_key(json_key_io)
         json_key = MultiJson.load(json_key_io.read)
-        raise 'missing client_email' unless json_key.key?('client_email')
-        raise 'missing private_key' unless json_key.key?('private_key')
-        project_id = json_key['project_id']
-        [json_key['private_key'], json_key['client_email'], project_id]
+        raise "missing client_email" unless json_key.key?("client_email")
+        raise "missing private_key" unless json_key.key?("private_key")
+        project_id = json_key["project_id"]
+        [json_key["private_key"], json_key["client_email"], project_id]
       end
     end
   end

--- a/lib/googleauth/scope_util.rb
+++ b/lib/googleauth/scope_util.rb
@@ -27,18 +27,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/signet'
-require 'googleauth/credentials_loader'
-require 'multi_json'
+require "googleauth/signet"
+require "googleauth/credentials_loader"
+require "multi_json"
 
 module Google
   module Auth
     # Small utility for normalizing scopes into canonical form
     module ScopeUtil
       ALIASES = {
-        'email' => 'https://www.googleapis.com/auth/userinfo.email',
-        'profile' => 'https://www.googleapis.com/auth/userinfo.profile',
-        'openid' => 'https://www.googleapis.com/auth/plus.me'
+        "email" => "https://www.googleapis.com/auth/userinfo.email",
+        "profile" => "https://www.googleapis.com/auth/userinfo.profile",
+        "openid" => "https://www.googleapis.com/auth/plus.me"
       }.freeze
 
       def self.normalize(scope)
@@ -51,9 +51,9 @@ module Google
         when Array
           scope
         when String
-          scope.split(' ')
+          scope.split(" ")
         else
-          raise 'Invalid scope value. Must be string or array'
+          raise "Invalid scope value. Must be string or array"
         end
       end
     end

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -27,12 +27,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/signet'
-require 'googleauth/credentials_loader'
-require 'googleauth/json_key_reader'
-require 'jwt'
-require 'multi_json'
-require 'stringio'
+require "googleauth/signet"
+require "googleauth/credentials_loader"
+require "googleauth/json_key_reader"
+require "jwt"
+require "multi_json"
+require "stringio"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -47,7 +47,7 @@ module Google
     #
     # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
     class ServiceAccountCredentials < Signet::OAuth2::Client
-      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v4/token'.freeze
+      TOKEN_CRED_URI = "https://www.googleapis.com/oauth2/v4/token".freeze
       extend CredentialsLoader
       extend JsonKeyReader
       attr_reader :project_id
@@ -127,8 +127,8 @@ module Google
     class ServiceAccountJwtHeaderCredentials
       JWT_AUD_URI_KEY = :jwt_aud_uri
       AUTH_METADATA_KEY = Signet::OAuth2::AUTH_METADATA_KEY
-      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v4/token'.freeze
-      SIGNING_ALGORITHM = 'RS256'.freeze
+      TOKEN_CRED_URI = "https://www.googleapis.com/oauth2/v4/token".freeze
+      SIGNING_ALGORITHM = "RS256".freeze
       EXPIRY = 60
       extend CredentialsLoader
       extend JsonKeyReader
@@ -194,11 +194,11 @@ module Google
         now = Time.new
         skew = options[:skew] || 60
         assertion = {
-          'iss' => @issuer,
-          'sub' => @issuer,
-          'aud' => jwt_aud_uri,
-          'exp' => (now + EXPIRY).to_i,
-          'iat' => (now - skew).to_i
+          "iss" => @issuer,
+          "sub" => @issuer,
+          "aud" => jwt_aud_uri,
+          "exp" => (now + EXPIRY).to_i,
+          "iat" => (now - skew).to_i
         }
         JWT.encode(assertion, @signing_key, SIGNING_ALGORITHM)
       end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'signet/oauth_2/client'
+require "signet/oauth_2/client"
 
 module Signet
   # OAuth2 supports OAuth2 authentication.

--- a/lib/googleauth/stores/file_token_store.rb
+++ b/lib/googleauth/stores/file_token_store.rb
@@ -27,8 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'yaml/store'
-require 'googleauth/token_store'
+require "yaml/store"
+require "googleauth/token_store"
 
 module Google
   module Auth

--- a/lib/googleauth/stores/redis_token_store.rb
+++ b/lib/googleauth/stores/redis_token_store.rb
@@ -27,8 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'redis'
-require 'googleauth/token_store'
+require "redis"
+require "googleauth/token_store"
 
 module Google
   module Auth
@@ -37,7 +37,7 @@ module Google
       # are stored as JSON using the supplied key, prefixed with
       # `g-user-token:`
       class RedisTokenStore < Google::Auth::TokenStore
-        DEFAULT_KEY_PREFIX = 'g-user-token:'.freeze
+        DEFAULT_KEY_PREFIX = "g-user-token:".freeze
 
         # Create a new store with the supplied redis client.
         #

--- a/lib/googleauth/token_store.rb
+++ b/lib/googleauth/token_store.rb
@@ -44,7 +44,7 @@ module Google
       # @return [String]
       #  The loaded token data.
       def load(_id)
-        raise 'Not implemented'
+        raise "Not implemented"
       end
 
       # Put the token data into storage for the given ID.
@@ -54,7 +54,7 @@ module Google
       # @param [String] token
       #  The token data to store.
       def store(_id, _token)
-        raise 'Not implemented'
+        raise "Not implemented"
       end
 
       # Remove the token data from storage for the given ID.
@@ -62,7 +62,7 @@ module Google
       # @param [String] id
       #  ID of the token data to delete
       def delete(_id)
-        raise 'Not implemented'
+        raise "Not implemented"
       end
     end
   end

--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -27,10 +27,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'uri'
-require 'multi_json'
-require 'googleauth/signet'
-require 'googleauth/user_refresh'
+require "uri"
+require "multi_json"
+require "googleauth/signet"
+require "googleauth/user_refresh"
 
 module Google
   module Auth
@@ -53,11 +53,11 @@ module Google
     #     ...
     class UserAuthorizer
       MISMATCHED_CLIENT_ID_ERROR =
-        'Token client ID of %s does not match configured client id %s'.freeze
-      NIL_CLIENT_ID_ERROR = 'Client id can not be nil.'.freeze
-      NIL_SCOPE_ERROR = 'Scope can not be nil.'.freeze
-      NIL_USER_ID_ERROR = 'User ID can not be nil.'.freeze
-      NIL_TOKEN_STORE_ERROR = 'Can not call method if token store is nil'.freeze
+        "Token client ID of %s does not match configured client id %s".freeze
+      NIL_CLIENT_ID_ERROR = "Client id can not be nil.".freeze
+      NIL_SCOPE_ERROR = "Scope can not be nil.".freeze
+      NIL_USER_ID_ERROR = "User ID can not be nil.".freeze
+      NIL_TOKEN_STORE_ERROR = "Can not call method if token store is nil".freeze
       MISSING_ABSOLUTE_URL_ERROR =
         'Absolute base url required for relative callback url "%s"'.freeze
 
@@ -79,7 +79,7 @@ module Google
         @client_id = client_id
         @scope = Array(scope)
         @token_store = token_store
-        @callback_uri = callback_uri || '/oauth2callback'
+        @callback_uri = callback_uri || "/oauth2callback"
       end
 
       # Build the URL for requesting authorization.
@@ -105,9 +105,9 @@ module Google
           scope: scope
         )
         redirect_uri = redirect_uri_for(options[:base_url])
-        url = credentials.authorization_uri(access_type: 'offline',
+        url = credentials.authorization_uri(access_type: "offline",
                                             redirect_uri: redirect_uri,
-                                            approval_prompt: 'force',
+                                            approval_prompt: "force",
                                             state: options[:state],
                                             include_granted_scopes: true,
                                             login_hint: options[:login_hint])
@@ -128,18 +128,18 @@ module Google
         return nil if saved_token.nil?
         data = MultiJson.load(saved_token)
 
-        if data.fetch('client_id', @client_id.id) != @client_id.id
+        if data.fetch("client_id", @client_id.id) != @client_id.id
           raise sprintf(MISMATCHED_CLIENT_ID_ERROR,
-                        data['client_id'], @client_id.id)
+                        data["client_id"], @client_id.id)
         end
 
         credentials = UserRefreshCredentials.new(
           client_id: @client_id.id,
           client_secret: @client_id.secret,
-          scope: data['scope'] || @scope,
-          access_token: data['access_token'],
-          refresh_token: data['refresh_token'],
-          expires_at: data.fetch('expiration_time_millis', 0) / 1000
+          scope: data["scope"] || @scope,
+          access_token: data["access_token"],
+          refresh_token: data["refresh_token"],
+          expires_at: data.fetch("expiration_time_millis", 0) / 1000
         )
         scope ||= @scope
         if credentials.includes_scope?(scope)

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -27,10 +27,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'googleauth/signet'
-require 'googleauth/credentials_loader'
-require 'googleauth/scope_util'
-require 'multi_json'
+require "googleauth/signet"
+require "googleauth/credentials_loader"
+require "googleauth/scope_util"
+require "multi_json"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -46,9 +46,9 @@ module Google
     #
     # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
     class UserRefreshCredentials < Signet::OAuth2::Client
-      TOKEN_CRED_URI = 'https://oauth2.googleapis.com/token'.freeze
-      AUTHORIZATION_URI = 'https://accounts.google.com/o/oauth2/auth'.freeze
-      REVOKE_TOKEN_URI = 'https://oauth2.googleapis.com/revoke'.freeze
+      TOKEN_CRED_URI = "https://oauth2.googleapis.com/token".freeze
+      AUTHORIZATION_URI = "https://accounts.google.com/o/oauth2/auth".freeze
+      REVOKE_TOKEN_URI = "https://oauth2.googleapis.com/revoke".freeze
       extend CredentialsLoader
       attr_reader :project_id
 
@@ -60,17 +60,17 @@ module Google
         json_key_io, scope = options.values_at(:json_key_io, :scope)
         user_creds = read_json_key(json_key_io) if json_key_io
         user_creds ||= {
-          'client_id'     => ENV[CredentialsLoader::CLIENT_ID_VAR],
-          'client_secret' => ENV[CredentialsLoader::CLIENT_SECRET_VAR],
-          'refresh_token' => ENV[CredentialsLoader::REFRESH_TOKEN_VAR],
-          'project_id'    => ENV[CredentialsLoader::PROJECT_ID_VAR]
+          "client_id"     => ENV[CredentialsLoader::CLIENT_ID_VAR],
+          "client_secret" => ENV[CredentialsLoader::CLIENT_SECRET_VAR],
+          "refresh_token" => ENV[CredentialsLoader::REFRESH_TOKEN_VAR],
+          "project_id"    => ENV[CredentialsLoader::PROJECT_ID_VAR]
         }
 
         new(token_credential_uri: TOKEN_CRED_URI,
-            client_id: user_creds['client_id'],
-            client_secret: user_creds['client_secret'],
-            refresh_token: user_creds['refresh_token'],
-            project_id:    user_creds['project_id'],
+            client_id: user_creds["client_id"],
+            client_secret: user_creds["client_secret"],
+            refresh_token: user_creds["refresh_token"],
+            project_id:    user_creds["project_id"],
             scope: scope)
           .configure_connection(options)
       end

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.8.0'.freeze
+    VERSION = "0.8.0".freeze
   end
 end

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -27,11 +27,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'multi_json'
-require 'googleauth/signet'
-require 'googleauth/user_authorizer'
-require 'googleauth/user_refresh'
-require 'securerandom'
+require "multi_json"
+require "googleauth/signet"
+require "googleauth/user_authorizer"
+require "googleauth/user_refresh"
+require "securerandom"
 
 module Google
   module Auth
@@ -66,21 +66,21 @@ module Google
     # @see {Google::Auth::ControllerHelpers}
     # @note Requires sessions are enabled
     class WebUserAuthorizer < Google::Auth::UserAuthorizer
-      STATE_PARAM = 'state'.freeze
-      AUTH_CODE_KEY = 'code'.freeze
-      ERROR_CODE_KEY = 'error'.freeze
-      SESSION_ID_KEY = 'session_id'.freeze
-      CALLBACK_STATE_KEY = 'g-auth-callback'.freeze
-      CURRENT_URI_KEY = 'current_uri'.freeze
-      XSRF_KEY = 'g-xsrf-token'.freeze
-      SCOPE_KEY = 'scope'.freeze
+      STATE_PARAM = "state".freeze
+      AUTH_CODE_KEY = "code".freeze
+      ERROR_CODE_KEY = "error".freeze
+      SESSION_ID_KEY = "session_id".freeze
+      CALLBACK_STATE_KEY = "g-auth-callback".freeze
+      CURRENT_URI_KEY = "current_uri".freeze
+      XSRF_KEY = "g-xsrf-token".freeze
+      SCOPE_KEY = "scope".freeze
 
-      NIL_REQUEST_ERROR = 'Request is required.'.freeze
-      NIL_SESSION_ERROR = 'Sessions must be enabled'.freeze
-      MISSING_AUTH_CODE_ERROR = 'Missing authorization code in request'.freeze
-      AUTHORIZATION_ERROR = 'Authorization error: %s'.freeze
+      NIL_REQUEST_ERROR = "Request is required.".freeze
+      NIL_SESSION_ERROR = "Sessions must be enabled".freeze
+      MISSING_AUTH_CODE_ERROR = "Missing authorization code in request".freeze
+      AUTHORIZATION_ERROR = "Authorization error: %s".freeze
       INVALID_STATE_TOKEN_ERROR =
-        'State token does not match expected value'.freeze
+        "State token does not match expected value".freeze
 
       class << self
         attr_accessor :default
@@ -205,7 +205,7 @@ module Google
       end
 
       def self.extract_callback_state(request)
-        state = MultiJson.load(request[STATE_PARAM] || '{}')
+        state = MultiJson.load(request[STATE_PARAM] || "{}")
         redirect_uri = state[CURRENT_URI_KEY]
         callback_state = {
           AUTH_CODE_KEY => request[AUTH_CODE_KEY],
@@ -259,7 +259,7 @@ module Google
       #
       # @see {Google::Auth::WebUserAuthorizer}
       class CallbackApp
-        LOCATION_HEADER = 'Location'.freeze
+        LOCATION_HEADER = "Location".freeze
         REDIR_STATUS = 302
         ERROR_STATUS = 500
 
@@ -281,7 +281,7 @@ module Google
           if return_url
             [REDIR_STATUS, { LOCATION_HEADER => return_url }, []]
           else
-            [ERROR_STATUS, {}, ['No return URL is present in the request.']]
+            [ERROR_STATUS, {}, ["No return URL is present in the request."]]
           end
         end
 


### PR DESCRIPTION
* Fixes https://github.com/googleapis/google-auth-library-ruby/issues/192
* Add double-quotes to linter rules and run `rubocop --auto-correct`