### PR TITLE
Release google-auth-library-ruby 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 ## 0.6.0 (2017/10/17)
 
+### 0.8.1 / 2019-02-22
+
+* switch gcloud command to IO.popen from backticks (#194)
+
 ### Changes
 
 * Support ruby-jwt 2.0


### PR DESCRIPTION
* switch gcloud command to IO.popen from backticks (#194)

This pull request was generated using releasetool.