### PR TITLE
Release google-auth-library-ruby 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.8.1 / 2019-02-27
 
-* silence unnecessary gcloud warning
+* Silence unnecessary gcloud warning
 
 ### 0.8.0 / 2019-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.8.1 / 2019-02-27
+
+* silence unnecessary gcloud warning
+
 ### 0.8.0 / 2019-01-02
 
 * Support connection options :default_connection and :connection_builder when creating credentials that need to refresh OAuth tokens. This lets clients provide connection objects with custom settings, such as proxies, needed for the client environment.

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.8.0".freeze
+    VERSION = "0.8.1".freeze
   end
 end


### PR DESCRIPTION
* silence unnecessary gcloud warning

This pull request was generated using releasetool.