### PR TITLE
Release google-auth-library-ruby 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.8.1 / 2019-03-27
+
+* Silence unnecessary gcloud warning
+* Treat empty credentials environment variables as unset
+
 ### 0.8.0 / 2019-01-02
 
 * Support connection options :default_connection and :connection_builder when creating credentials that need to refresh OAuth tokens. This lets clients provide connection objects with custom settings, such as proxies, needed for the client environment.

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.8.0".freeze
+    VERSION = "0.8.1".freeze
   end
 end


### PR DESCRIPTION
* Silence unnecessary gcloud warning
* Treat empty credentials environment variables as unset

This pull request was generated using releasetool.