### PR TITLE
Bump the minimum supported Ruby version from 1.9 to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Metrics/ClassLength:
   Max: 110
 Metrics/ModuleLength:
   Max: 110
+Metrics/BlockLength:
+  Exclude:
+    - "googleauth.gemspec"

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Custom storage implementations can also be used. See
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 1.9+.
+This library is currently supported on Ruby 2.3+.
 
 However, Ruby 2.4 or later is strongly recommended, as earlier releases have
 reached or are nearing end-of-life. After March 31, 2019, Google will provide

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   end
   gem.require_paths = ["lib"]
   gem.platform      = Gem::Platform::RUBY
+  gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency "faraday", "~> 0.12"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"


### PR DESCRIPTION
This pull request bumps the minimum supported Ruby version from 1.9 to 2.3.

Ruby on Rails CI for 5-2-stable with Ruby 2.2.10 and google-auth-library-ruby 0.8.1 has been failing
https://travis-ci.org/rails/rails/jobs/512320216#L1788

```ruby
    NOT_FOUND_ERROR = <<~ERROR_MESSAGE.freeze
```

Since #203 introduces indented here document `<<~` which
is available only for Ruby 2.3 https://bugs.ruby-lang.org/issues/9098

Refer https://github.com/googleapis/google-auth-library-ruby/issues/111#issuecomment-477966192