### PR TITLE
Fix the gcloud command to avoid spamming stderr when unauthorized.

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -49,7 +49,8 @@ module Google
       PROJECT_ID_VAR            = "GOOGLE_PROJECT_ID".freeze
       GCLOUD_POSIX_COMMAND      = "gcloud".freeze
       GCLOUD_WINDOWS_COMMAND    = "gcloud.cmd".freeze
-      GCLOUD_CONFIG_COMMAND     = "config config-helper --format json".freeze
+      GCLOUD_CONFIG_COMMAND     =
+        "config config-helper --format json --verbosity none".freeze
 
       CREDENTIALS_FILE_NAME = "application_default_credentials.json".freeze
       NOT_FOUND_ERROR =


### PR DESCRIPTION
Without this change, creating the default credentials when gcloud credentials are not set results in the following on stderr:
```
$ ruby -e 'require "googleauth"; Google::Auth::Credentials.default'
ERROR: (gcloud.config.config-helper) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials, or if you have already logged in with a
different account:

  $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
```
See also googleapis/google-cloud-ruby#2986.