### PR TITLE
Allow specifying custom state key-values

### DIFF
--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -154,6 +154,8 @@ module Google
       # @param [String, Array<String>] scope
       #  Authorization scope to request. Overrides the instance scopes if
       #  not nil.
+      # @param [Hash] state
+      #  Optional key-values to be returned to the oauth callback.
       # @return [String]
       #  Authorization url
       def get_authorization_url options = {}
@@ -162,12 +164,14 @@ module Google
         raise NIL_REQUEST_ERROR if request.nil?
         raise NIL_SESSION_ERROR if request.session.nil?
 
+        state = options[:state] || {}
+
         redirect_to = options[:redirect_to] || request.url
         request.session[XSRF_KEY] = SecureRandom.base64
-        options[:state] = MultiJson.dump(
+        options[:state] = MultiJson.dump(state.merge(
           SESSION_ID_KEY  => request.session[XSRF_KEY],
           CURRENT_URI_KEY => redirect_to
-        )
+        ))
         options[:base_url] = request.url
         super options
       end

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -169,9 +169,9 @@ module Google
         redirect_to = options[:redirect_to] || request.url
         request.session[XSRF_KEY] = SecureRandom.base64
         options[:state] = MultiJson.dump(state.merge(
-          SESSION_ID_KEY  => request.session[XSRF_KEY],
-          CURRENT_URI_KEY => redirect_to
-        ))
+                                           SESSION_ID_KEY  => request.session[XSRF_KEY],
+                                           CURRENT_URI_KEY => redirect_to
+                                         ))
         options[:base_url] = request.url
         super options
       end

--- a/spec/googleauth/web_user_authorizer_spec.rb
+++ b/spec/googleauth/web_user_authorizer_spec.rb
@@ -63,6 +63,12 @@ describe Google::Auth::WebUserAuthorizer do
       )
     end
 
+    it "should allow adding custom state key-value pairs" do
+      url = authorizer.get_authorization_url request: request, state: { james: "bond", kind: 1 }
+      expect(url).to match(%r{%22james%22:%22bond%22})
+      expect(url).to match(%r{%22kind%22:1})
+    end
+
     it "should include request forgery token in state" do
       expect(SecureRandom).to receive(:base64).and_return("aGVsbG8=")
       url = authorizer.get_authorization_url request: request


### PR DESCRIPTION
This PR adds the ability to specify custom `state` key-value pairs so that they can be forwarded to the callback.

Closes https://github.com/googleapis/google-auth-library-ruby/issues/217