### PR TITLE
Release google-auth-library-ruby 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+### 0.9.0 / 2019-06-24
+
+add retry on error for fetch_access_token (#213)
+
+allow specifying custom state key-values (#218)
+
+add verbosity none to gcloud command (#215)
+
+Credentials: Use methods instead of constants (#212)
+Update Credentials to use methods for values that are intended to
+be changed by users, replacing constants.
+Add Credentials documentation.
+
+Credentials Environment Variable Refactor (#211)
+* Refactor env var methods
+Have the iteration return for the first match, instead of comparing
+all elements and choosing the first one that matches.
+* Combine file and json credentials detection
+Allow an environment variable to contain either a file path
+or JSON to describe the credentials.
+This change matches how these variables are used in Google Cloud.
+
+Bump the minimum supported Ruby version from 1.9 to 2.3 (#208)
+
 ### 0.8.1 / 2019-03-27
 
 * Silence unnecessary gcloud warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,9 @@
 ### 0.9.0 / 2019-06-24
 
-add retry on error for fetch_access_token (#213)
-
-allow specifying custom state key-values (#218)
-
-add verbosity none to gcloud command (#215)
-
-Credentials: Use methods instead of constants (#212)
-Update Credentials to use methods for values that are intended to
-be changed by users, replacing constants.
-Add Credentials documentation.
-
-Credentials Environment Variable Refactor (#211)
-* Refactor env var methods
-Have the iteration return for the first match, instead of comparing
-all elements and choosing the first one that matches.
-* Combine file and json credentials detection
-Allow an environment variable to contain either a file path
-or JSON to describe the credentials.
-This change matches how these variables are used in Google Cloud.
-
-Bump the minimum supported Ruby version from 1.9 to 2.3 (#208)
+* Access token requests will now retry.
+* WebUserAuthorizer#get_authorization_url merges with state, rather than overwriting it.
+* Combine file and json credentials detection for environment variables
+* Bump the minimum supported Ruby version from 1.9 to 2.3
 
 ### 0.8.1 / 2019-03-27
 

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.8.1".freeze
+    VERSION = "0.9.0".freeze
   end
 end


### PR DESCRIPTION
* Access token requests will now retry.
* WebUserAuthorizer#get_authorization_url merges with state, rather than overwriting it.
* Combine file and json credentials detection for environment variables
* Bump the minimum supported Ruby version from 1.9 to 2.3

<details><summary>Commits since previous release</summary><pre><code>commit b9531ea66234ef41814cb32eb8957663eebc4db6
Author: Piotr Usewicz <piotr@layer22.com>
Date:   Tue Jun 11 20:08:43 2019 +0200

    remove Travis build status (#219)
    
    Travis is not configured for this repo anymore.

commit e85ce29f0043f71d5f7754b492b1526e827f91ab
Author: Ryan Brushett <RyanBrushett@users.noreply.github.com>
Date:   Mon Jun 10 16:52:45 2019 -0400

    add retry on error for fetch_access_token (#213)

commit 9e797f13b88ca666ca2ca2fd72602a2b4f177b16
Author: Piotr Usewicz <piotr@layer22.com>
Date:   Mon Jun 10 20:21:11 2019 +0200

    allow specifying custom state key-values (#218)

commit f2f83b20bc1f32db0c90cf5cea0922d0558a35b0
Author: igorpeshansky <igorpeshansky@users.noreply.github.com>
Date:   Wed May 15 19:06:10 2019 -0400

    add verbosity none to gcloud command (#215)

commit a33a640e611d6a18531e8a5a27a7791a47d8799a
Author: Mike Moore <mike@blowmage.com>
Date:   Tue May 7 17:56:17 2019 -0600

    Credentials: Use methods instead of constants (#212)
    
    Update Credentials to use methods for values that are intended to
    be changed by users, replacing constants.
    Add Credentials documentation.

commit 63381e4d9c0aab4985310e92902e6983a3f56ee1
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue May 7 12:13:17 2019 -0600

    Fix Rubocop errors (#214)
    
    * Fix for google-style 0.3.0 change to Style/WordArray.
    * Update google-style dependency to 0.3.

commit f6e8355edd19be17406b052ac1c64d3a595768e8
Author: Mike Moore <mike@blowmage.com>
Date:   Wed May 1 15:04:48 2019 -0600

    Credentials Environment Variable Refactor (#211)
    
    * Refactor env var methods
      Have the iteration return for the first match, instead of comparing
      all elements and choosing the first one that matches.
    * Combine file and json credentials detection
      Allow an environment variable to contain either a file path
      or JSON to describe the credentials.
      This change matches how these variables are used in Google Cloud.

commit b4feeb6188df86fd788eea073a60e6a9ed8726da
Author: Graham Paye <gpaye8@gmail.com>
Date:   Thu Apr 4 13:20:58 2019 -0700

    setup windows builds to track google-cloud-ruby (#209)

commit 9ca53d24ff5ad85cd125dc2dd741f129237f87d0
Author: Yasuo Honda <yasuo.honda@gmail.com>
Date:   Fri Apr 5 02:21:27 2019 +0900

    Bump the minimum supported Ruby version from 1.9 to 2.3 (#208)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/.kokoro/build.bat b/.kokoro/build.bat
index ba3fdbc..5ff89c8 100644
--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -5,4 +5,12 @@ REM  * Merges run all non-acceptance tests for every library, and acceptance tes
 REM  * Nightlies run all acceptance tests for every library.
 REM Currently only runs tests on 2.5.1
 
-"C:\Program Files\Git\bin\bash.exe" github/google-auth-library-ruby/.kokoro/windows.sh
+SET url="https://raw.githubusercontent.com/googleapis/google-cloud-ruby/master/.kokoro/build.bat"
+
+SET "download=powershell -C Invoke-WebRequest -Uri %url% -OutFile master-build.bat"
+
+SET EXIT_STATUS=1
+
+%download% && master-build.bat && SET EXIT_STATUS=0
+
+EXIT %EXIT_STATUS%
diff --git a/.kokoro/continuous/windows.cfg b/.kokoro/continuous/windows.cfg
index 8a73e4e..ff953f8 100644
--- a/.kokoro/continuous/windows.cfg
+++ b/.kokoro/continuous/windows.cfg
@@ -1,3 +1,19 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "google-auth-library-ruby/.kokoro/build.bat"
+build_file: "google-auth-library-ruby/.kokoro/trampoline.bat"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/windows"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-ruby/.kokoro/build.bat"
+}
+
+env_vars: {
+    key: "REPO_DIR"
+    value: "google-auth-library-ruby"
+}
diff --git a/.kokoro/presubmit/windows.cfg b/.kokoro/presubmit/windows.cfg
index 8a73e4e..ff953f8 100644
--- a/.kokoro/presubmit/windows.cfg
+++ b/.kokoro/presubmit/windows.cfg
@@ -1,3 +1,19 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "google-auth-library-ruby/.kokoro/build.bat"
+build_file: "google-auth-library-ruby/.kokoro/trampoline.bat"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/windows"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-ruby/.kokoro/build.bat"
+}
+
+env_vars: {
+    key: "REPO_DIR"
+    value: "google-auth-library-ruby"
+}
diff --git a/.kokoro/trampoline.bat b/.kokoro/trampoline.bat
new file mode 100644
index 0000000..1634b07
--- /dev/null
+++ b/.kokoro/trampoline.bat
@@ -0,0 +1,10 @@
+
+SET url="https://raw.githubusercontent.com/googleapis/google-cloud-ruby/master/.kokoro/trampoline.bat"
+
+SET "download=powershell -C Invoke-WebRequest -Uri %url% -OutFile master-trampoline.bat"
+
+SET EXIT_STATUS=1
+
+%download% && master-trampoline.bat && SET EXIT_STATUS=0
+
+EXIT %EXIT_STATUS%
diff --git a/.kokoro/windows.sh b/.kokoro/windows.sh
deleted file mode 100644
index 68b09f4..0000000
--- a/.kokoro/windows.sh
+++ /dev/null
@@ -1,4 +0,0 @@
-#!/bin/bash
-
-script_url="https://raw.githubusercontent.com/googleapis/google-cloud-ruby/master/.kokoro/windows.sh"
-curl -o master-windows.sh $script_url && source master-windows.sh
diff --git a/.rubocop.yml b/.rubocop.yml
index 00faa63..3a555f6 100644
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,5 +7,10 @@ AllCops:
     - "Rakefile"
 Metrics/ClassLength:
   Max: 110
+  Exclude:
+    - "lib/googleauth/credentials.rb"
 Metrics/ModuleLength:
   Max: 110
+Metrics/BlockLength:
+  Exclude:
+    - "googleauth.gemspec"
diff --git a/Gemfile b/Gemfile
index 136e757..93840b8 100755
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "coveralls", "~> 0.7"
   gem "fakefs", "~> 0.6"
   gem "fakeredis", "~> 0.5"
-  gem "google-style", "~> 0.2"
+  gem "google-style", "~> 0.3"
   gem "logging", "~> 2.0"
   gem "rack-test", "~> 0.6"
   gem "rake", "~> 10.0"
diff --git a/README.md b/README.md
index bb112de..381a5d6 100644
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 </dl>
 
 [![Gem Version](https://badge.fury.io/rb/googleauth.svg)](http://badge.fury.io/rb/googleauth)
-[![Build Status](https://secure.travis-ci.org/google/google-auth-library-ruby.svg)](http://travis-ci.org/google/google-auth-library-ruby)
 [![Coverage Status](https://coveralls.io/repos/google/google-auth-library-ruby/badge.svg)](https://coveralls.io/r/google/google-auth-library-ruby)
 
 ## Description
@@ -184,7 +183,7 @@ Custom storage implementations can also be used. See
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 1.9+.
+This library is currently supported on Ruby 2.3+.
 
 However, Ruby 2.4 or later is strongly recommended, as earlier releases have
 reached or are nearing end-of-life. After March 31, 2019, Google will provide
diff --git a/googleauth.gemspec b/googleauth.gemspec
index 5605b94..5513f8a 100755
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   end
   gem.require_paths = ["lib"]
   gem.platform      = Gem::Platform::RUBY
+  gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency "faraday", "~> 0.12"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
diff --git a/lib/googleauth/credentials.rb b/lib/googleauth/credentials.rb
index f30dd6b..4db5954 100644
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -35,26 +35,206 @@ require "googleauth/credentials_loader"
 
 module Google
   module Auth
-    # This class is intended to be inherited by API-specific classes
-    # which overrides the SCOPE constant.
+    ##
+    # Credentials is responsible for representing the authentication when connecting to an API. This
+    # class is also intended to be inherited by API-specific classes.
     class Credentials
+      ##
+      # The default token credential URI to be used when none is provided during initialization.
       TOKEN_CREDENTIAL_URI = "https://oauth2.googleapis.com/token".freeze
+
+      ##
+      # The default target audience ID to be used when none is provided during initialization.
       AUDIENCE = "https://oauth2.googleapis.com/token".freeze
-      SCOPE = [].freeze
-      PATH_ENV_VARS = [].freeze
-      JSON_ENV_VARS = [].freeze
-      DEFAULT_PATHS = [].freeze
 
+      ##
+      # The default token credential URI to be used when none is provided during initialization.
+      # The URI is the authorization server's HTTP endpoint capable of issuing tokens and
+      # refreshing expired tokens.
+      #
+      # @return [String]
+      #
+      def self.token_credential_uri
+        return @token_credential_uri unless @token_credential_uri.nil?
+
+        const_get :TOKEN_CREDENTIAL_URI if const_defined? :TOKEN_CREDENTIAL_URI
+      end
+
+      ##
+      # Set the default token credential URI to be used when none is provided during initialization.
+      #
+      # @param [String] new_token_credential_uri
+      # @return [String]
+      #
+      def self.token_credential_uri= new_token_credential_uri
+        @token_credential_uri = new_token_credential_uri
+      end
+
+      ##
+      # The default target audience ID to be used when none is provided during initialization.
+      # Used only by the assertion grant type.
+      #
+      # @return [String]
+      #
+      def self.audience
+        return @audience unless @audience.nil?
+
+        const_get :AUDIENCE if const_defined? :AUDIENCE
+      end
+
+      ##
+      # Sets the default target audience ID to be used when none is provided during initialization.
+      #
+      # @param [String] new_audience
+      # @return [String]
+      #
+      def self.audience= new_audience
+        @audience = new_audience
+      end
+
+      ##
+      # The default scope to be used when none is provided during initialization.
+      # A scope is an access range defined by the authorization server.
+      # The scope can be a single value or a list of values.
+      #
+      # @return [String, Array<String>]
+      #
+      def self.scope
+        return @scope unless @scope.nil?
+
+        tmp_scope = []
+        # Pull in values is the SCOPE constant exists.
+        tmp_scope << const_get(:SCOPE) if const_defined? :SCOPE
+        tmp_scope.flatten.uniq
+      end
+
+      ##
+      # Sets the default scope to be used when none is provided during initialization.
+      #
+      # @param [String, Array<String>] new_scope
+      # @return [String, Array<String>]
+      #
+      def self.scope= new_scope
+        new_scope = Array new_scope unless new_scope.nil?
+        @scope = new_scope
+      end
+
+      ##
+      # The environment variables to search for credentials. Values can either be a file path to the
+      # credentials file, or the JSON contents of the credentials file.
+      #
+      # @return [Array<String>]
+      #
+      def self.env_vars
+        return @env_vars unless @env_vars.nil?
+
+        # Pull values when PATH_ENV_VARS or JSON_ENV_VARS constants exists.
+        tmp_env_vars = []
+        tmp_env_vars << const_get(:PATH_ENV_VARS) if const_defined? :PATH_ENV_VARS
+        tmp_env_vars << const_get(:JSON_ENV_VARS) if const_defined? :JSON_ENV_VARS
+        tmp_env_vars.flatten.uniq
+      end
+
+      ##
+      # Sets the environment variables to search for credentials.
+      #
+      # @param [Array<String>] new_env_vars
+      # @return [Array<String>]
+      #
+      def self.env_vars= new_env_vars
+        new_env_vars = Array new_env_vars unless new_env_vars.nil?
+        @env_vars = new_env_vars
+      end
+
+      ##
+      # The file paths to search for credentials files.
+      #
+      # @return [Array<String>]
+      #
+      def self.paths
+        return @paths unless @paths.nil?
+
+        tmp_paths = []
+        # Pull in values is the DEFAULT_PATHS constant exists.
+        tmp_paths << const_get(:DEFAULT_PATHS) if const_defined? :DEFAULT_PATHS
+        tmp_paths.flatten.uniq
+      end
+
+      ##
+      # Set the file paths to search for credentials files.
+      #
+      # @param [Array<String>] new_paths
+      # @return [Array<String>]
+      #
+      def self.paths= new_paths
+        new_paths = Array new_paths unless new_paths.nil?
+        @paths = new_paths
+      end
+
+      ##
+      # The Signet::OAuth2::Client object the Credentials instance is using.
+      #
+      # @return [Signet::OAuth2::Client]
+      #
       attr_accessor :client
-      attr_reader   :project_id
 
-      # Delegate client methods to the client object.
+      ##
+      # Identifier for the project the client is authenticating with.
+      #
+      # @return [String]
+      #
+      attr_reader :project_id
+
+      # @private Delegate client methods to the client object.
       extend Forwardable
+
+      ##
+      # @!attribute [r] token_credential_uri
+      #   @return [String] The token credential URI. The URI is the authorization server's HTTP
+      #     endpoint capable of issuing tokens and refreshing expired tokens.
+      #
+      # @!attribute [r] audience
+      #   @return [String] The target audience ID when issuing assertions. Used only by the
+      #     assertion grant type.
+      #
+      # @!attribute [r] scope
+      #   @return [String, Array<String>] The scope for this client. A scope is an access range
+      #     defined by the authorization server. The scope can be a single value or a list of values.
+      #
+      # @!attribute [r] issuer
+      #   @return [String] The issuer ID associated with this client.
+      #
+      # @!attribute [r] signing_key
+      #   @return [String, OpenSSL::PKey] The signing key associated with this client.
+      #
+      # @!attribute [r] updater_proc
+      #   @return [Proc] Returns a reference to the {Signet::OAuth2::Client#apply} method,
+      #     suitable for passing as a closure.
+      #
       def_delegators :@client,
                      :token_credential_uri, :audience,
                      :scope, :issuer, :signing_key, :updater_proc
 
       # rubocop:disable Metrics/AbcSize
+
+      ##
+      # Creates a new Credentials instance with the provided auth credentials, and with the default
+      # values configured on the class.
+      #
+      # @param [String, Hash, Signet::OAuth2::Client] keyfile
+      #   The keyfile can be provided as one of the following:
+      #
+      #   * The path to a JSON keyfile (as a +String+)
+      #   * The contents of a JSON keyfile (as a +Hash+)
+      #   * A +Signet::OAuth2::Client+ object
+      # @param [Hash] options
+      #   The options for configuring the credentials instance. The following is supported:
+      #
+      #   * +:scope+ - the scope for the client
+      #   * +"project_id"+ (and optionally +"project"+) - the project identifier for the client
+      #   * +:connection_builder+ - the connection builder to use for the client
+      #   * +:default_connection+ - the default connection to use for the client
+      #
       def initialize keyfile, options = {}
         scope = options[:scope]
         verify_keyfile_provided! keyfile
@@ -80,18 +260,32 @@ module Google
       end
       # rubocop:enable Metrics/AbcSize
 
-      # Returns the default credentials checking, in this order, the path env
-      # evironment variables, json environment variables, default paths. If the
-      # previously stated locations do not contain keyfile information,
-      # this method defaults to use the application default.
+      ##
+      # Creates a new Credentials instance with auth credentials acquired by searching the
+      # environment variables and paths configured on the class, and with the default values
+      # configured on the class.
+      #
+      # The auth credentials are searched for in the following order:
+      #
+      # 1. configured environment variables (see {Credentials.env_vars})
+      # 2. configured default file paths (see {Credentials.paths})
+      # 3. application default (see {Google::Auth.get_application_default})
+      #
+      # @param [Hash] options
+      #   The options for configuring the credentials instance. The following is supported:
+      #
+      #   * +:scope+ - the scope for the client
+      #   * +"project_id"+ (and optionally +"project"+) - the project identifier for the client
+      #   * +:connection_builder+ - the connection builder to use for the client
+      #   * +:default_connection+ - the default connection to use for the client
+      #
+      # @return [Credentials]
+      #
       def self.default options = {}
-        # First try to find keyfile file from environment variables.
-        client = from_path_vars options
-
-        # Second try to find keyfile json from environment variables.
-        client ||= from_json_vars options
+        # First try to find keyfile file or json from environment variables.
+        client = from_env_vars options
 
-        # Third try to find keyfile file from known file paths.
+        # Second try to find keyfile file from known file paths.
         client ||= from_default_paths options
 
         # Finally get instantiated client from Google::Auth
@@ -99,33 +293,22 @@ module Google
         client
       end
 
-      def self.from_path_vars options
-        self::PATH_ENV_VARS
-          .map { |v| ENV[v] }
-          .compact
-          .select { |p| ::File.file? p }
-          .each do |file|
-            return new file, options
-          end
-        nil
-      end
-
-      def self.from_json_vars options
-        json = lambda do |v|
-          unless ENV[v].nil?
-            begin
-              JSON.parse ENV[v]
-            rescue StandardError
-              nil
-            end
-          end
+      ##
+      # @private Lookup Credentials from environment variables.
+      def self.from_env_vars options
+        env_vars.each do |env_var|
+          str = ENV[env_var]
+          next if str.nil?
+          return new str, options if ::File.file? str
+          return new ::JSON.parse(str), options rescue nil
         end
-        self::JSON_ENV_VARS.map(&json).compact.each { |hash| return new hash, options }
         nil
       end
 
+      ##
+      # @private Lookup Credentials from default file paths.
       def self.from_default_paths options
-        self::DEFAULT_PATHS
+        paths
           .select { |p| ::File.file? p }
           .each do |file|
             return new file, options
@@ -133,13 +316,15 @@ module Google
         nil
       end
 
+      ##
+      # @private Lookup Credentials using Google::Auth.get_application_default.
       def self.from_application_default options
-        scope = options[:scope] || self::SCOPE
+        scope = options[:scope] || self.scope
         client = Google::Auth.get_application_default scope
         new client, options
       end
-      private_class_method :from_path_vars,
-                           :from_json_vars,
+
+      private_class_method :from_env_vars,
                            :from_default_paths,
                            :from_application_default
 
@@ -171,9 +356,9 @@ module Google
 
       def client_options options
         # Keyfile options have higher priority over constructor defaults
-        options["token_credential_uri"] ||= self.class::TOKEN_CREDENTIAL_URI
-        options["audience"] ||= self.class::AUDIENCE
-        options["scope"] ||= self.class::SCOPE
+        options["token_credential_uri"] ||= self.class.token_credential_uri
+        options["audience"] ||= self.class.audience
+        options["scope"] ||= self.class.scope
 
         # client options for initializing signet client
         { token_credential_uri: options["token_credential_uri"],
diff --git a/lib/googleauth/credentials_loader.rb b/lib/googleauth/credentials_loader.rb
index eecdca0..43d0757 100644
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -49,7 +49,8 @@ module Google
       PROJECT_ID_VAR            = "GOOGLE_PROJECT_ID".freeze
       GCLOUD_POSIX_COMMAND      = "gcloud".freeze
       GCLOUD_WINDOWS_COMMAND    = "gcloud.cmd".freeze
-      GCLOUD_CONFIG_COMMAND     = "config config-helper --format json".freeze
+      GCLOUD_CONFIG_COMMAND     =
+        "config config-helper --format json --verbosity none".freeze
 
       CREDENTIALS_FILE_NAME = "application_default_credentials.json".freeze
       NOT_FOUND_ERROR =
diff --git a/lib/googleauth/signet.rb b/lib/googleauth/signet.rb
index cdb9256..4313247 100644
--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -76,7 +76,9 @@ module Signet
           connection = build_default_connection
           options = options.merge connection: connection if connection
         end
-        info = orig_fetch_access_token! options
+        info = retry_with_error do
+          orig_fetch_access_token! options
+        end
         notify_refresh_listeners
         info
       end
diff --git a/lib/googleauth/user_refresh.rb b/lib/googleauth/user_refresh.rb
index 0fb9abc..f3c4fda 100644
--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -79,7 +79,7 @@ module Google
       # JSON key.
       def self.read_json_key json_key_io
         json_key = MultiJson.load json_key_io.read
-        wanted = %w[client_id client_secret refresh_token]
+        wanted = ["client_id", "client_secret", "refresh_token"]
         wanted.each do |key|
           raise "the json is missing the #{key} field" unless json_key.key? key
         end
diff --git a/lib/googleauth/web_user_authorizer.rb b/lib/googleauth/web_user_authorizer.rb
index be6c9d8..3c14ddd 100644
--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -154,6 +154,8 @@ module Google
       # @param [String, Array<String>] scope
       #  Authorization scope to request. Overrides the instance scopes if
       #  not nil.
+      # @param [Hash] state
+      #  Optional key-values to be returned to the oauth callback.
       # @return [String]
       #  Authorization url
       def get_authorization_url options = {}
@@ -162,12 +164,14 @@ module Google
         raise NIL_REQUEST_ERROR if request.nil?
         raise NIL_SESSION_ERROR if request.session.nil?
 
+        state = options[:state] || {}
+
         redirect_to = options[:redirect_to] || request.url
         request.session[XSRF_KEY] = SecureRandom.base64
-        options[:state] = MultiJson.dump(
-          SESSION_ID_KEY  => request.session[XSRF_KEY],
-          CURRENT_URI_KEY => redirect_to
-        )
+        options[:state] = MultiJson.dump(state.merge(
+                                           SESSION_ID_KEY  => request.session[XSRF_KEY],
+                                           CURRENT_URI_KEY => redirect_to
+                                         ))
         options[:base_url] = request.url
         super options
       end
diff --git a/spec/googleauth/credentials_spec.rb b/spec/googleauth/credentials_spec.rb
index df4163d..3cb2183 100644
--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -81,181 +81,367 @@ describe Google::Auth::Credentials, :private do
     Google::Auth::Credentials.new default_keyfile_hash, scope: "http://example.com/scope"
   end
 
-  it "can be subclassed to pass in other env paths" do
-    TEST_PATH_ENV_VAR = "TEST_PATH".freeze
-    TEST_PATH_ENV_VAL = "/unknown/path/to/file.txt".freeze
-    TEST_JSON_ENV_VAR = "TEST_JSON_VARS".freeze
-
-    ENV[TEST_PATH_ENV_VAR] = TEST_PATH_ENV_VAL
-    ENV[TEST_JSON_ENV_VAR] = JSON.generate default_keyfile_hash
-
-    class TestCredentials < Google::Auth::Credentials
-      SCOPE = "http://example.com/scope".freeze
-      PATH_ENV_VARS = [TEST_PATH_ENV_VAR].freeze
-      JSON_ENV_VARS = [TEST_JSON_ENV_VAR].freeze
+  describe "using CONSTANTS" do
+    it "can be subclassed to pass in other env paths" do
+      test_path_env_val = "/unknown/path/to/file.txt".freeze
+      test_json_env_val = JSON.generate default_keyfile_hash
+
+      ENV["TEST_PATH"] = test_path_env_val
+      ENV["TEST_JSON_VARS"] = test_json_env_val
+
+      class TestCredentials1 < Google::Auth::Credentials
+        TOKEN_CREDENTIAL_URI = "https://example.com/token".freeze
+        AUDIENCE = "https://example.com/audience".freeze
+        SCOPE = "http://example.com/scope".freeze
+        PATH_ENV_VARS = ["TEST_PATH"].freeze
+        JSON_ENV_VARS = ["TEST_JSON_VARS"].freeze
+      end
+
+      allow(::File).to receive(:file?).with(test_path_env_val) { false }
+      allow(::File).to receive(:file?).with(test_json_env_val) { false }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://example.com/token")
+        expect(options[:audience]).to eq("https://example.com/audience")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials1.default
+      expect(creds).to be_a_kind_of(TestCredentials1)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    allow(::File).to receive(:file?).with(TEST_PATH_ENV_VAL) { false }
-
-    mocked_signet = double "Signet::OAuth2::Client"
-    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
-    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
-    allow(mocked_signet).to receive(:client_id)
-    allow(Signet::OAuth2::Client).to receive(:new) do |options|
-      expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:scope]).to eq(["http://example.com/scope"])
-      expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
-      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
-
-      mocked_signet
+    it "subclasses can use PATH_ENV_VARS to get keyfile path" do
+      class TestCredentials2 < Google::Auth::Credentials
+        SCOPE = "http://example.com/scope".freeze
+        PATH_ENV_VARS = %w[PATH_ENV_DUMMY PATH_ENV_TEST].freeze
+        JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
+        DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/unknown/path/to/file.txt") { true }
+      allow(::File).to receive(:read).with("/unknown/path/to/file.txt") { JSON.generate default_keyfile_hash }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials2.default
+      expect(creds).to be_a_kind_of(TestCredentials2)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    creds = TestCredentials.default
-    expect(creds).to be_a_kind_of(TestCredentials)
-    expect(creds.client).to eq(mocked_signet)
-    expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
-  end
-
-  it "subclasses can use PATH_ENV_VARS to get keyfile path" do
-    class TestCredentials < Google::Auth::Credentials
-      SCOPE = "http://example.com/scope".freeze
-      PATH_ENV_VARS = %w[PATH_ENV_DUMMY PATH_ENV_TEST].freeze
-      JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
-      DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+    it "subclasses can use JSON_ENV_VARS to get keyfile contents" do
+      test_json_env_val = JSON.generate default_keyfile_hash
+
+      class TestCredentials3 < Google::Auth::Credentials
+        SCOPE = "http://example.com/scope".freeze
+        PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
+        JSON_ENV_VARS = %w[JSON_ENV_DUMMY JSON_ENV_TEST].freeze
+        DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::File).to receive(:file?).with(test_json_env_val) { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_TEST") { test_json_env_val }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials3.default
+      expect(creds).to be_a_kind_of(TestCredentials3)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
-    allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
-    allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
-    allow(::File).to receive(:file?).with("/unknown/path/to/file.txt") { true }
-    allow(::File).to receive(:read).with("/unknown/path/to/file.txt") { JSON.generate default_keyfile_hash }
-
-    mocked_signet = double "Signet::OAuth2::Client"
-    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
-    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
-    allow(mocked_signet).to receive(:client_id)
-    allow(Signet::OAuth2::Client).to receive(:new) do |options|
-      expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:scope]).to eq(["http://example.com/scope"])
-      expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
-      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
-
-      mocked_signet
+    it "subclasses can use DEFAULT_PATHS to get keyfile path" do
+      class TestCredentials4 < Google::Auth::Credentials
+        SCOPE = "http://example.com/scope".freeze
+        PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
+        JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
+        DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { true }
+      allow(::File).to receive(:read).with("~/default/path/to/file.txt") { JSON.generate default_keyfile_hash }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials4.default
+      expect(creds).to be_a_kind_of(TestCredentials4)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    creds = TestCredentials.default
-    expect(creds).to be_a_kind_of(TestCredentials)
-    expect(creds.client).to eq(mocked_signet)
-    expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
-  end
-
-  it "subclasses can use JSON_ENV_VARS to get keyfile contents" do
-    class TestCredentials < Google::Auth::Credentials
-      SCOPE = "http://example.com/scope".freeze
-      PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
-      JSON_ENV_VARS = %w[JSON_ENV_DUMMY JSON_ENV_TEST].freeze
-      DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+    it "subclasses that find no matches default to Google::Auth.get_application_default" do
+      class TestCredentials5 < Google::Auth::Credentials
+        SCOPE = "http://example.com/scope".freeze
+        PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
+        JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
+        DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { false }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Google::Auth).to receive(:get_application_default) do |scope|
+        expect(scope).to eq([TestCredentials5::SCOPE])
+
+        # This should really be a Signet::OAuth2::Client object,
+        # but mocking is making that difficult, so return a valid hash instead.
+        default_keyfile_hash
+      end
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials5.default
+      expect(creds).to be_a_kind_of(TestCredentials5)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
-
-    allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
-    allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
-    allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
-    allow(::ENV).to receive(:[]).with("JSON_ENV_TEST") { JSON.generate default_keyfile_hash }
-
-    mocked_signet = double "Signet::OAuth2::Client"
-    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
-    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
-    allow(mocked_signet).to receive(:client_id)
-    allow(Signet::OAuth2::Client).to receive(:new) do |options|
-      expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:scope]).to eq(["http://example.com/scope"])
-      expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
-      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
-
-      mocked_signet
-    end
-
-    creds = TestCredentials.default
-    expect(creds).to be_a_kind_of(TestCredentials)
-    expect(creds.client).to eq(mocked_signet)
-    expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
   end
 
-  it "subclasses can use DEFAULT_PATHS to get keyfile path" do
-    class TestCredentials < Google::Auth::Credentials
-      SCOPE = "http://example.com/scope".freeze
-      PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
-      JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
-      DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+  describe "using class methods" do
+    it "can be subclassed to pass in other env paths" do
+      test_path_env_val = "/unknown/path/to/file.txt".freeze
+      test_json_env_val = JSON.generate default_keyfile_hash
+
+      ENV["TEST_PATH"] = test_path_env_val
+      ENV["TEST_JSON_VARS"] = test_json_env_val
+
+      class TestCredentials11 < Google::Auth::Credentials
+        self.token_credential_uri = "https://example.com/token"
+        self.audience = "https://example.com/audience"
+        self.scope = "http://example.com/scope"
+        self.env_vars = ["TEST_PATH", "TEST_JSON_VARS"]
+      end
+
+      allow(::File).to receive(:file?).with(test_path_env_val) { false }
+      allow(::File).to receive(:file?).with(test_json_env_val) { false }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://example.com/token")
+        expect(options[:audience]).to eq("https://example.com/audience")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials11.default
+      expect(creds).to be_a_kind_of(TestCredentials11)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
-    allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
-    allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
-    allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { true }
-    allow(::File).to receive(:read).with("~/default/path/to/file.txt") { JSON.generate default_keyfile_hash }
-
-    mocked_signet = double "Signet::OAuth2::Client"
-    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
-    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
-    allow(mocked_signet).to receive(:client_id)
-    allow(Signet::OAuth2::Client).to receive(:new) do |options|
-      expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:scope]).to eq(["http://example.com/scope"])
-      expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
-      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
-
-      mocked_signet
+    it "subclasses can use PATH_ENV_VARS to get keyfile path" do
+      class TestCredentials12 < Google::Auth::Credentials
+        self.scope = "http://example.com/scope"
+        self.env_vars = %w[PATH_ENV_DUMMY PATH_ENV_TEST JSON_ENV_DUMMY]
+        self.paths = ["~/default/path/to/file.txt"]
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/unknown/path/to/file.txt") { true }
+      allow(::File).to receive(:read).with("/unknown/path/to/file.txt") { JSON.generate default_keyfile_hash }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials12.default
+      expect(creds).to be_a_kind_of(TestCredentials12)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    creds = TestCredentials.default
-    expect(creds).to be_a_kind_of(TestCredentials)
-    expect(creds.client).to eq(mocked_signet)
-    expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
-  end
-
-  it "subclasses that find no matches default to Google::Auth.get_application_default" do
-    class TestCredentials < Google::Auth::Credentials
-      SCOPE = "http://example.com/scope".freeze
-      PATH_ENV_VARS = ["PATH_ENV_DUMMY"].freeze
-      JSON_ENV_VARS = ["JSON_ENV_DUMMY"].freeze
-      DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
+    it "subclasses can use JSON_ENV_VARS to get keyfile contents" do
+      test_json_env_val = JSON.generate default_keyfile_hash
+
+      class TestCredentials13 < Google::Auth::Credentials
+        self.scope = "http://example.com/scope"
+        self.env_vars = %w[PATH_ENV_DUMMY JSON_ENV_DUMMY JSON_ENV_TEST]
+        self.paths = ["~/default/path/to/file.txt"]
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::File).to receive(:file?).with(test_json_env_val) { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_TEST") { test_json_env_val }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials13.default
+      expect(creds).to be_a_kind_of(TestCredentials13)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
 
-    allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
-    allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
-    allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
-    allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { false }
-
-    mocked_signet = double "Signet::OAuth2::Client"
-    allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
-    allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
-    allow(mocked_signet).to receive(:client_id)
-    allow(Google::Auth).to receive(:get_application_default) do |scope|
-      expect(scope).to eq(TestCredentials::SCOPE)
-
-      # This should really be a Signet::OAuth2::Client object,
-      # but mocking is making that difficult, so return a valid hash instead.
-      default_keyfile_hash
+    it "subclasses can use DEFAULT_PATHS to get keyfile path" do
+      class TestCredentials14 < Google::Auth::Credentials
+        self.scope = "http://example.com/scope"
+        self.env_vars = %w[PATH_ENV_DUMMY JSON_ENV_DUMMY]
+        self.paths = ["~/default/path/to/file.txt"]
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { true }
+      allow(::File).to receive(:read).with("~/default/path/to/file.txt") { JSON.generate default_keyfile_hash }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials14.default
+      expect(creds).to be_a_kind_of(TestCredentials14)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
-    allow(Signet::OAuth2::Client).to receive(:new) do |options|
-      expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
-      expect(options[:scope]).to eq(["http://example.com/scope"])
-      expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
-      expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
 
-      mocked_signet
+    it "subclasses that find no matches default to Google::Auth.get_application_default" do
+      class TestCredentials15 < Google::Auth::Credentials
+        self.scope = "http://example.com/scope"
+        self.env_vars = %w[PATH_ENV_DUMMY JSON_ENV_DUMMY]
+        self.paths = ["~/default/path/to/file.txt"]
+      end
+
+      allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
+      allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
+      allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
+      allow(::File).to receive(:file?).with("~/default/path/to/file.txt") { false }
+
+      mocked_signet = double "Signet::OAuth2::Client"
+      allow(mocked_signet).to receive(:configure_connection).and_return(mocked_signet)
+      allow(mocked_signet).to receive(:fetch_access_token!).and_return(true)
+      allow(mocked_signet).to receive(:client_id)
+      allow(Google::Auth).to receive(:get_application_default) do |scope|
+        expect(scope).to eq(TestCredentials15.scope)
+
+        # This should really be a Signet::OAuth2::Client object,
+        # but mocking is making that difficult, so return a valid hash instead.
+        default_keyfile_hash
+      end
+      allow(Signet::OAuth2::Client).to receive(:new) do |options|
+        expect(options[:token_credential_uri]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:audience]).to eq("https://oauth2.googleapis.com/token")
+        expect(options[:scope]).to eq(["http://example.com/scope"])
+        expect(options[:issuer]).to eq(default_keyfile_hash["client_email"])
+        expect(options[:signing_key]).to be_a_kind_of(OpenSSL::PKey::RSA)
+
+        mocked_signet
+      end
+
+      creds = TestCredentials15.default
+      expect(creds).to be_a_kind_of(TestCredentials15)
+      expect(creds.client).to eq(mocked_signet)
+      expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
     end
-
-    creds = TestCredentials.default
-    expect(creds).to be_a_kind_of(TestCredentials)
-    expect(creds.client).to eq(mocked_signet)
-    expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
   end
 
   it "warns when cloud sdk credentials are used" do
diff --git a/spec/googleauth/signet_spec.rb b/spec/googleauth/signet_spec.rb
index 866d99d..46f05f6 100644
--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -100,4 +100,35 @@ describe Signet::OAuth2::Client do
       expect(stub).to have_been_requested
     end
   end
+
+  describe "#fetch_access_token!" do
+    it "retries when orig_fetch_access_token! raises Signet::RemoteServerError" do
+      mocked_responses = [:raise, :raise, "success"]
+      allow(@client).to receive(:orig_fetch_access_token!).exactly(3).times do
+        response = mocked_responses.shift
+        response == :raise ? raise(Signet::RemoteServerError) : response
+      end
+      expect(@client.fetch_access_token!).to eq("success")
+    end
+
+    it "raises when the max retry count is exceeded" do
+      mocked_responses = [:raise, :raise, :raise, :raise, :raise, :raise, "success"]
+      allow(@client).to receive(:orig_fetch_access_token!).exactly(6).times do
+        response = mocked_responses.shift
+        response == :raise ? raise(Signet::RemoteServerError) : response
+      end
+      expect { @client.fetch_access_token! }.to raise_error Signet::AuthorizationError
+    end
+
+    it "does not retry and raises right away if it encounters a Signet::AuthorizationError" do
+      allow(@client).to receive(:orig_fetch_access_token!).at_most(:once)
+        .and_raise(Signet::AuthorizationError.new("Some Message"))
+      expect { @client.fetch_access_token! }.to raise_error Signet::AuthorizationError
+    end
+
+    it "does not retry and raises right away if it encounters a Signet::ParseError" do
+      allow(@client).to receive(:orig_fetch_access_token!).at_most(:once).and_raise(Signet::ParseError)
+      expect { @client.fetch_access_token! }.to raise_error Signet::ParseError
+    end
+  end
 end
diff --git a/spec/googleauth/web_user_authorizer_spec.rb b/spec/googleauth/web_user_authorizer_spec.rb
index 6d299cd..20d4776 100644
--- a/spec/googleauth/web_user_authorizer_spec.rb
+++ b/spec/googleauth/web_user_authorizer_spec.rb
@@ -63,6 +63,12 @@ describe Google::Auth::WebUserAuthorizer do
       )
     end
 
+    it "should allow adding custom state key-value pairs" do
+      url = authorizer.get_authorization_url request: request, state: { james: "bond", kind: 1 }
+      expect(url).to match(%r{%22james%22:%22bond%22})
+      expect(url).to match(%r{%22kind%22:1})
+    end
+
     it "should include request forgery token in state" do
       expect(SecureRandom).to receive(:base64).and_return("aGVsbG8=")
       url = authorizer.get_authorization_url request: request

```

</details>

This pull request was generated using releasetool.