### PR TITLE
Make the header check case insensitive

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -75,7 +75,6 @@ module Google
             req.options.timeout = 0.1
           end
           return false unless resp.status == 200
-          return false unless resp.headers.key? "Metadata-Flavor"
           resp.headers["Metadata-Flavor"] == "Google"
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
           false


### PR DESCRIPTION
According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
>  Field names are case-insensitive

Some proxies like envoy for istio when setup in a GKE pod, they intercept all traffic and they does convert all headers to lower case. This made the check `on_gce?` fails because the response has these headers
```
content-type: application/text
metadata-flavor: Google
server: envoy
date: Sun, 21 Jul 2019 11:13:04 GMT
content-length: 17
x-envoy-upstream-service-time: 0
```
And from this response it is clear that the header `Metadata-Flavor` has been changed to `metadata-flavor`