### PR TITLE
GKE Metadata Server requires header "Metadata-Flavor": "Google" at COMPUTE_CHECK_URI

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -62,7 +62,8 @@ module Google
         # is available
         def on_gce? options = {}
           c = options[:connection] || Faraday.default_connection
-          resp = c.get COMPUTE_CHECK_URI do |req|
+          headers = { "Metadata-Flavor" => "Google" }
+          resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|
             # Comment from: oauth2client/client.py
             #
             # Note: the explicit `timeout` below is a workaround. The underlying

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -97,6 +97,7 @@ describe Google::Auth::GCECredentials do
   describe "#on_gce?" do
     it "should be true when Metadata-Flavor is Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(true)
@@ -105,6 +106,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false when Metadata-Flavor is not Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
@@ -113,6 +115,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false if the response is not 200" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  404,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)


### PR DESCRIPTION
In GKE 1.13.7-gke.8, COMPUTE_CHECK_URI(http://169.254.169.254) requires the header "Metadata-Flavor": "Google".

```
# curl http://169.254.169.254 -vvv
* Rebuilt URL to: http://169.254.169.254/
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET / HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 403 Forbidden
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 07 Aug 2019 14:33:12 GMT
< Content-Length: 94
< 
GKE Metadata Server encountered an error: Missing required header "Metadata-Flavor": "Google"
* Connection #0 to host 169.254.169.254 left intact

# curl -H 'Metadata-Flavor:Google' http://169.254.169.254 -vvv
* Rebuilt URL to: http://169.254.169.254/
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET / HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
> Metadata-Flavor:Google
> 
< HTTP/1.1 200 OK
< Content-Type: application/text
< Metadata-Flavor: Google
< Server: GKE Metadata Server
< Date: Wed, 07 Aug 2019 14:33:15 GMT
< Content-Length: 17
< 
computeMetadata/
* Connection #0 to host 169.254.169.254 left intact
```

In GKE v1.12.7-gke.25 and GKE v1.11.10-gke.5, COMPUTE_CHECK_URI do not require the header "Metadata-Flavor": "Google" and the request to COMPUTE_CHECK_URI can be executed with the header(the result is below).

```
# curl -H 'Metadata-Flavor:Google' http://169.254.169.254 -vv
* Rebuilt URL to: http://169.254.169.254/
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET / HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
> Metadata-Flavor:Google
> 
< HTTP/1.1 200 OK
< Metadata-Flavor: Google
< Content-Type: application/text
< Date: Wed, 07 Aug 2019 14:17:02 GMT
< Server: Metadata Server for VM
< Content-Length: 22
< X-XSS-Protection: 0
< X-Frame-Options: SAMEORIGIN
< 
0.1/
computeMetadata/
```
