### PR TITLE
Set instance variables at initialization to avoid spamming rake warnings.

### DIFF
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -257,6 +257,9 @@ module Google
         CredentialsLoader.warn_if_cloud_sdk_credentials @client.client_id
         @project_id ||= CredentialsLoader.load_gcloud_project_id
         @client.fetch_access_token!
+        @env_vars = nil
+        @paths = nil
+        @scope = nil
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -38,6 +38,11 @@ module Signet
     # This reopens Client to add #apply and #apply! methods which update a
     # hash with the fetched authentication token.
     class Client
+      def initialize
+        super
+        @refresh_listeners = nil
+      end
+
       def configure_connection options
         @connection_info =
           options[:connection_builder] || options[:default_connection]

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -84,11 +84,7 @@ module Signet
       end
 
       def notify_refresh_listeners
-        if defined? @refresh_listeners
-          listeners = @refresh_listeners
-        else
-          listeners = []
-        end
+        listeners = defined?(@refresh_listeners) ? @refresh_listeners : []
         listeners.each do |block|
           block.call self
         end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -38,11 +38,6 @@ module Signet
     # This reopens Client to add #apply and #apply! methods which update a
     # hash with the fetched authentication token.
     class Client
-      def initialize
-        super
-        @refresh_listeners = nil
-      end
-
       def configure_connection options
         @connection_info =
           options[:connection_builder] || options[:default_connection]
@@ -71,7 +66,7 @@ module Signet
       end
 
       def on_refresh &block
-        @refresh_listeners ||= []
+        @refresh_listeners = [] unless defined? @refresh_listeners
         @refresh_listeners << block
       end
 
@@ -89,7 +84,11 @@ module Signet
       end
 
       def notify_refresh_listeners
-        listeners = @refresh_listeners || []
+        if defined? @refresh_listeners
+          listeners = @refresh_listeners
+        else
+          listeners = []
+        end
         listeners.each do |block|
           block.call self
         end


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-auth-library-ruby/issues/227.