### PR TITLE
Fix Metadata API access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.9.1 / 2019-08-23
+
+* Add GKE Metadata-Flavor fix
+
 ### 0.9.0 / 2019-08-05
 
 * Restore compatibility with Ruby 2.0. This is the last release that will work on end-of-lifed versions of Ruby. The 0.10 release will require Ruby 2.4 or later.

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -62,7 +62,8 @@ ERROR
         # is available
         def on_gce? options = {}
           c = options[:connection] || Faraday.default_connection
-          resp = c.get COMPUTE_CHECK_URI do |req|
+          headers = { "Metadata-Flavor" => "Google" }
+          resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|
             # Comment from: oauth2client/client.py
             #
             # Note: the explicit `timeout` below is a workaround. The underlying

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.9.0".freeze
+    VERSION = "0.9.1".freeze
   end
 end

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -97,6 +97,7 @@ describe Google::Auth::GCECredentials do
   describe "#on_gce?" do
     it "should be true when Metadata-Flavor is Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(true)
@@ -105,6 +106,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false when Metadata-Flavor is not Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
@@ -113,6 +115,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false if the response is not 200" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  404,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)


### PR DESCRIPTION
This creates a 0.9.1 release which includes the cherry-picked commit fixing the lack of Metadata-Flavor HTTP request header when using this gem in a GCE environment.

At the moment, gems like google-cloud-storage require a version of googleauth <0.10. This means it is not possible to simply use the git master version of googleauth where the fixes have been applied.

It probably needs merging onto a new 0.9.1 branch but I'm not sure how I could do that in a PR.