### PR TITLE
support an environment variable to suppress Cloud SDK credentials warnings

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -70,7 +70,9 @@ module Google
         "application continues to use end user credentials from Cloud SDK, "\
         'you might receive a "quota exceeded" or "API not enabled" error. For'\
         " more information about service accounts, see "\
-        "https://cloud.google.com/docs/authentication/.".freeze
+        "https://cloud.google.com/docs/authentication/. "\
+        "To suppress this message, set the "\
+        "GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS environment variable".freeze
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -167,6 +169,7 @@ module Google
 
       # Issues warning if cloud sdk client id is used
       def warn_if_cloud_sdk_credentials client_id
+        return if ENV["GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS"]
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
 

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -64,15 +64,13 @@ module Google
       CLOUD_SDK_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.app"\
         "s.googleusercontent.com".freeze
 
-      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated "\
-        "using end user credentials from Google Cloud SDK. We recommend that "\
-        "most server applications use service accounts instead. If your "\
-        "application continues to use end user credentials from Cloud SDK, "\
-        'you might receive a "quota exceeded" or "API not enabled" error. For'\
-        " more information about service accounts, see "\
-        "https://cloud.google.com/docs/authentication/. "\
-        "To suppress this message, set the "\
-        "GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS environment variable".freeze
+      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated using end user "\
+        "credentials from Google Cloud SDK. We recommend that most server applications use "\
+        "service accounts instead. If your application continues to use end user credentials "\
+        'from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For '\
+        "more information about service accounts, see "\
+        "https://cloud.google.com/docs/authentication/. To suppress this message, set the "\
+        "GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS environment variable.".freeze
 
       # make_creds proxies the construction of a credentials instance
       #

--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -128,6 +128,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -164,6 +165,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -198,6 +200,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -232,6 +235,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -310,6 +314,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -345,6 +350,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -378,6 +384,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -411,6 +418,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }


### PR DESCRIPTION
Currently, this library always issues the following warning when using end user credentials:

> Your application has authenticated using end user credentials from
> Google Cloud SDK. We recommend that most server applications use service
> accounts instead. If your application continues to use end user
> credentials from Cloud SDK, you might receive a "quota exceeded" or "API
> not enabled" error. For more information about service accounts, see
> https://cloud.google.com/docs/authentication/

This is helpful, but it can wear thin during local development. This
commit adds an environment variable that the library user can set if the
warning's annoying; if they care enough to read the message properly and
to set the environment variable, they probably know what they're doing
with it.

@dazuma had this input about how they documented a similar environment
variable for suppressing warnings in `google-cloud-ruby`:

> In the google-cloud-ruby libraries, we "documented" it by including
> instructions for how to suppress the warning message, in the message
> itself. I think that remains a reasonable approach here. (It wasn't
> clear to us that there would be a better way to document it, especially
> because most users aren't going to depend on this library directly, but
> only transitively via some other library.)

See #233 - see the issue for discussion.