### PR TITLE
Require Ruby 2.4 and Signet 0.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "coveralls", "~> 0.7"
   gem "fakefs", "~> 0.6"
   gem "fakeredis", "~> 0.5"
-  gem "google-style", "~> 0.3"
+  gem "google-style", "~> 1.24.0"
   gem "logging", "~> 2.0"
   gem "rack-test", "~> 0.6"
   gem "rake", "~> 10.0"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Google Auth Library for Ruby
 
 <dl>
-  <dt>Homepage</dt><dd><a href="http://www.github.com/google/google-auth-library-ruby">http://www.github.com/google/google-auth-library-ruby</a></dd>
+  <dt>Homepage</dt><dd><a href="http://www.github.com/googleapis/google-auth-library-ruby">http://www.github.com/googleapis/google-auth-library-ruby</a></dd>
   <dt>Authors</dt><dd><a href="mailto:temiola@google.com">Tim Emiola</a></dd>
   <dt>Copyright</dt><dd>Copyright © 2015 Google, Inc.</dd>
   <dt>License</dt><dd>Apache 2.0</dd>
 </dl>
 
 [![Gem Version](https://badge.fury.io/rb/googleauth.svg)](http://badge.fury.io/rb/googleauth)
-[![Coverage Status](https://coveralls.io/repos/google/google-auth-library-ruby/badge.svg)](https://coveralls.io/r/google/google-auth-library-ruby)
 
 ## Description
 
@@ -183,11 +182,9 @@ Custom storage implementations can also be used. See
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 2.3+.
+This library requires Ruby 2.4 or later.
 
-However, Ruby 2.4 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After March 31, 2019, Google will provide
-official support only for Ruby versions that are considered current and
+In general, this library supports Ruby versions that are considered current and
 supported by Ruby Core (that is, Ruby versions that are either in normal
 maintenance or in security maintenance).
 See https://www.ruby-lang.org/en/downloads/branches/ for further details.

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |gem|
   end
   gem.require_paths = ["lib"]
   gem.platform      = Gem::Platform::RUBY
-  gem.required_ruby_version = ">= 2.3.0"
+  gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_dependency "faraday", "~> 0.12"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "~> 0.7"
+  gem.add_dependency "signet", "~> 0.12"
 end


### PR DESCRIPTION
This is not going to pass tests until signet 0.12.0 is released, but opening the PR so we have all the proposals available.