### PR TITLE
fix: Increase metadata timeout, matching the logic in google-cloud-env

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -60,9 +60,8 @@ module Google
 
         # Detect if this appear to be a GCE instance, by checking if metadata
         # is available.
-        #
-        # TODO: This should use google-cloud-env.
         def on_gce? options = {}
+          # TODO: This should use google-cloud-env instead.
           c = options[:connection] || Faraday.default_connection
           headers = { "Metadata-Flavor" => "Google" }
           resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -59,20 +59,15 @@ module Google
         extend Memoist
 
         # Detect if this appear to be a GCE instance, by checking if metadata
-        # is available
+        # is available.
+        #
+        # TODO: This should use google-cloud-env.
         def on_gce? options = {}
           c = options[:connection] || Faraday.default_connection
           headers = { "Metadata-Flavor" => "Google" }
           resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|
-            # Comment from: oauth2client/client.py
-            #
-            # Note: the explicit `timeout` below is a workaround. The underlying
-            # issue is that resolving an unknown host on some networks will take
-            # 20-30 seconds; making this timeout short fixes the issue, but
-            # could lead to false negatives in the event that we are on GCE, but
-            # the metadata resolution was particularly slow. The latter case is
-            # "unlikely".
-            req.options.timeout = 0.1
+            req.options.timeout = 1.0
+            req.options.open_timeout = 0.1
           end
           return false unless resp.status == 200
           resp.headers["Metadata-Flavor"] == "Google"


### PR DESCRIPTION
Keep `open_timeout` low to keep the "fail-fast" behavior on non-gce hosts. But increase overall `timeout` to reduce false negatives since some metadata service instances can take a few moments to warm up. (In particular, this warmup behavior is sometimes observed on Titanium-based hosting.) This matches the settings we converged on in the google-cloud-env gem.

Fixes #226 