### PR TITLE
Release google-auth-library-ruby 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 0.10.0 / 2019-10-09
+
+Note: This release now requires Ruby 2.4 or later
+
+* Increase metadata timeout to improve reliability in some hosting environments
+* Support an environment variable to suppress Cloud SDK credentials warnings
+* Make the header check case insensitive
+* Set instance variables at initialization to avoid spamming warnings
+* Pass "Metadata-Flavor" header to metadata server when checking for GCE
+
 ### 0.10.0 / Unreleased
 
 * Requires Ruby 2.4 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ Note: This release now requires Ruby 2.4 or later
 * Set instance variables at initialization to avoid spamming warnings
 * Pass "Metadata-Flavor" header to metadata server when checking for GCE
 
-### 0.10.0 / Unreleased
-
-* Requires Ruby 2.4 or later.
-
 ### 0.9.0 / 2019-08-05
 
 * Restore compatibility with Ruby 2.0. This is the last release that will work on end-of-lifed versions of Ruby. The 0.10 release will require Ruby 2.4 or later.


### PR DESCRIPTION
Note: This release now requires Ruby 2.4 or later

* Increase metadata timeout to improve reliability in some hosting environments
* Support an environment variable to suppress Cloud SDK credentials warnings
* Make the header check case insensitive
* Set instance variables at initialization to avoid spamming warnings
* Pass "Metadata-Flavor" header to metadata server when checking for GCE

<details><summary>Commits since previous release</summary><pre><code>commit fe4220244c196a626d43093e6d806b02af983c3b
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 11:25:44 2019 -0700

    Require Ruby 2.4 and Signet 0.12 (#236)

commit 5523a75fc379d2d4554e7edd80490454181b6a69
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 10:55:44 2019 -0700

    Fixes to release scripts (#238)

commit 41bb5f13b2053e24b7b176a704a14d26daf80125
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Oct 8 11:33:03 2019 -0700

    fix: Increase metadata timeout, matching the logic in google-cloud-env

commit 9c46b3b049cd24c2541e9808d4f2b7e0e6e7f333
Author: Cera <ceralena.davies@gmail.com>
Date:   Wed Oct 9 04:00:36 2019 +1100

    feat: Support an environment variable to suppress Cloud SDK credentials warnings

commit be7599f53635b8b9ecc1b53bfce84ed38e083cab
Author: Abdulrahman Khalil <a.skhalil93@gmail.com>
Date:   Tue Oct 8 05:44:54 2019 +0300

    Make the header check case insensitive (#223)

commit 356d8fcaa89e0f0ac4626b62469189cd7b787a50
Author: Graham Paye <paye@google.com>
Date:   Tue Sep 24 08:05:26 2019 -0700

    chore: set os and trampoline_script (#234)

commit 2cd6af174d727a110cd4e874793ec9d93c91c3a2
Author: Ling Huang <qingling128@users.noreply.github.com>
Date:   Thu Aug 15 21:46:38 2019 -0400

    fix: Set instance variables at initialization to avoid spamming rake warnings

commit efb9b7897a696f54d58c0d828eb91c59cfa171af
Author: Spring_MT <today.is.sky.blue.sky@gmail.com>
Date:   Wed Aug 14 02:28:08 2019 +0900

    fix: Pass "Metadata-Flavor" header to metadata server when checking for GCE

commit 464d2650d0536778200968fb5374972d36d632b3
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Aug 5 18:55:27 2019 -0700

    Prepare for v0.10 development
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/.kokoro/continuous/linux.cfg b/.kokoro/continuous/linux.cfg
index e7a371d..a5cdf41 100644
--- a/.kokoro/continuous/linux.cfg
+++ b/.kokoro/continuous/linux.cfg
@@ -13,3 +13,13 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
diff --git a/.kokoro/continuous/osx.cfg b/.kokoro/continuous/osx.cfg
index b1c6c3b..55fdacf 100644
--- a/.kokoro/continuous/osx.cfg
+++ b/.kokoro/continuous/osx.cfg
@@ -1,3 +1,8 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "google-auth-library-ruby/.kokoro/osx.sh"
+
+env_vars: {
+    key: "OS"
+    value: "osx"
+}
diff --git a/.kokoro/continuous/windows.cfg b/.kokoro/continuous/windows.cfg
index ff953f8..b2dd2cc 100644
--- a/.kokoro/continuous/windows.cfg
+++ b/.kokoro/continuous/windows.cfg
@@ -13,7 +13,17 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.bat"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_windows.py"
+}
+
 env_vars: {
     key: "REPO_DIR"
     value: "google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "OS"
+    value: "windows"
+}
diff --git a/.kokoro/presubmit/linux.cfg b/.kokoro/presubmit/linux.cfg
index 9ea4ac3..5953ad8 100644
--- a/.kokoro/presubmit/linux.cfg
+++ b/.kokoro/presubmit/linux.cfg
@@ -12,3 +12,13 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
diff --git a/.kokoro/presubmit/osx.cfg b/.kokoro/presubmit/osx.cfg
index b1c6c3b..55fdacf 100644
--- a/.kokoro/presubmit/osx.cfg
+++ b/.kokoro/presubmit/osx.cfg
@@ -1,3 +1,8 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "google-auth-library-ruby/.kokoro/osx.sh"
+
+env_vars: {
+    key: "OS"
+    value: "osx"
+}
diff --git a/.kokoro/presubmit/windows.cfg b/.kokoro/presubmit/windows.cfg
index ff953f8..b2dd2cc 100644
--- a/.kokoro/presubmit/windows.cfg
+++ b/.kokoro/presubmit/windows.cfg
@@ -13,7 +13,17 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.bat"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_windows.py"
+}
+
 env_vars: {
     key: "REPO_DIR"
     value: "google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "OS"
+    value: "windows"
+}
diff --git a/.kokoro/release.cfg b/.kokoro/release.cfg
index 2ec59ed..ec95571 100644
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -17,6 +17,37 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
 # Download resources for system tests (service account key, etc.)
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
 
@@ -37,6 +68,11 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
 env_vars: {
     key: "JOB_TYPE"
     value: "release"
@@ -51,3 +87,8 @@ env_vars: {
     key: "REPO_DIR"
     value: "github/google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "PACKAGE"
+    value: "googleauth"
+}
diff --git a/.rubocop.yml b/.rubocop.yml
index bda4f78..b560582 100644
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,42 +1,18 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "spec/**/*"
     - "Rakefile"
-
-Metrics/AbcSize:
-  Max: 25
+Metrics/ClassLength:
+  Max: 110
+  Exclude:
+    - "lib/googleauth/credentials.rb"
+Metrics/ModuleLength:
+  Max: 110
 Metrics/BlockLength:
   Exclude:
     - "googleauth.gemspec"
-Metrics/CyclomaticComplexity:
-  Max: 8
-Metrics/PerceivedComplexity:
-  Max: 8
-Metrics/LineLength:
-  Max: 120
-Metrics/MethodLength:
-  Max: 21
-Metrics/ModuleLength:
-  Max: 150
-Metrics/ClassLength:
-  Enabled: false
-Layout/IndentHeredoc:
-  Enabled: false
-Style/FormatString:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
-Style/PercentLiteralDelimiters: # Contradicting rule
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/SymbolArray: # Undefined syntax in Ruby 1.9.3
-  Enabled: false
-Style/MethodDefParentheses:
-  Enabled: false
-Style/WordArray:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/RescueModifier:
+Style/SafeNavigation:
   Enabled: false
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 3a3d6de..430e2c3 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.10.0 / Unreleased
+
+* Requires Ruby 2.4 or later.
+
 ### 0.9.0 / 2019-08-05
 
 * Restore compatibility with Ruby 2.0. This is the last release that will work on end-of-lifed versions of Ruby. The 0.10 release will require Ruby 2.4 or later.
diff --git a/Gemfile b/Gemfile
index 9bc8d98..5122923 100755
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,12 @@ group :development do
   gem "coveralls", "~> 0.7"
   gem "fakefs", "~> 0.6"
   gem "fakeredis", "~> 0.5"
+  gem "google-style", "~> 1.24.0"
   gem "logging", "~> 2.0"
   gem "rack-test", "~> 0.6"
   gem "rake", "~> 10.0"
   gem "redis", "~> 3.2"
   gem "rspec", "~> 3.0"
-  gem "rubocop", ">= 0.41", "< 0.50"
   gem "simplecov", "~> 0.9"
   gem "sinatra"
   gem "webmock", "~> 1.21"
@@ -23,3 +23,5 @@ platforms :jruby do
   group :development do
   end
 end
+
+gem "gems", "~> 1.2"
diff --git a/README.md b/README.md
index 381a5d6..05a973f 100644
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Google Auth Library for Ruby
 
 <dl>
-  <dt>Homepage</dt><dd><a href="http://www.github.com/google/google-auth-library-ruby">http://www.github.com/google/google-auth-library-ruby</a></dd>
+  <dt>Homepage</dt><dd><a href="http://www.github.com/googleapis/google-auth-library-ruby">http://www.github.com/googleapis/google-auth-library-ruby</a></dd>
   <dt>Authors</dt><dd><a href="mailto:temiola@google.com">Tim Emiola</a></dd>
   <dt>Copyright</dt><dd>Copyright © 2015 Google, Inc.</dd>
   <dt>License</dt><dd>Apache 2.0</dd>
 </dl>
 
 [![Gem Version](https://badge.fury.io/rb/googleauth.svg)](http://badge.fury.io/rb/googleauth)
-[![Coverage Status](https://coveralls.io/repos/google/google-auth-library-ruby/badge.svg)](https://coveralls.io/r/google/google-auth-library-ruby)
 
 ## Description
 
@@ -183,11 +182,9 @@ Custom storage implementations can also be used. See
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 2.3+.
+This library requires Ruby 2.4 or later.
 
-However, Ruby 2.4 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After March 31, 2019, Google will provide
-official support only for Ruby versions that are considered current and
+In general, this library supports Ruby versions that are considered current and
 supported by Ruby Core (that is, Ruby versions that are either in normal
 maintenance or in security maintenance).
 See https://www.ruby-lang.org/en/downloads/branches/ for further details.
diff --git a/Rakefile b/Rakefile
index 0b5c311..4f71c3c 100755
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # -*- ruby -*-
+require "json"
 require "bundler/gem_tasks"
 
 task :ci do
@@ -7,12 +8,12 @@ task :ci do
   sh "bundle exec rspec"
 end
 
-task :release, :tag do |_t, args|
+task :release_gem, :tag do |_t, args|
   tag = args[:tag]
   raise "You must provide a tag to release." if tag.nil?
 
   # Verify the tag format "vVERSION"
-  m = tag.match(/v(?<version>\S*)/)
+  m = tag.match(/google-auth-library-ruby\/v(?<version>\S*)/)
   raise "Tag #{tag} does not match the expected format." if m.nil?
 
   version = m[:version]
@@ -33,7 +34,7 @@ task :release, :tag do |_t, args|
     sh "bundle exec rake build"
   end
 
-  path_to_be_pushed = "pkg/#{version}.gem"
+  path_to_be_pushed = "pkg/googleauth-#{version}.gem"
   if File.file? path_to_be_pushed
     begin
       ::Gems.push File.new(path_to_be_pushed)
@@ -75,7 +76,7 @@ namespace :kokoro do
                 .first.split("(").last.split(")").first || "0.1.0"
     end
     Rake::Task["kokoro:load_env_vars"].invoke
-    Rake::Task["release"].invoke "v/#{version}"
+    Rake::Task["release_gem"].invoke "google-auth-library-ruby/v#{version}"
   end
 end
 
diff --git a/googleauth.gemspec b/googleauth.gemspec
index 4d4d560..921c021 100755
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # encoding: utf-8
 
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "googleauth/version"
 
 Gem::Specification.new do |gem|
@@ -25,11 +25,12 @@ Gem::Specification.new do |gem|
   end
   gem.require_paths = ["lib"]
   gem.platform      = Gem::Platform::RUBY
+  gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_dependency "faraday", "~> 0.12"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "~> 0.7"
+  gem.add_dependency "signet", "~> 0.12"
 end
diff --git a/lib/googleauth/application_default.rb b/lib/googleauth/application_default.rb
index 774169c..4a5e3a2 100644
--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -34,11 +34,13 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NOT_FOUND_ERROR = <<-ERROR_MESSAGE.freeze
-Could not load the default credentials. Browse to
-https://developers.google.com/accounts/docs/application-default-credentials
-for more information
-ERROR_MESSAGE
+    NOT_FOUND_ERROR = <<~ERROR_MESSAGE.freeze
+      Could not load the default credentials. Browse to
+      https://developers.google.com/accounts/docs/application-default-credentials
+      for more information
+    ERROR_MESSAGE
+
+    module_function
 
     # Obtains the default credentials implementation to use in this
     # environment.
@@ -75,7 +77,5 @@ ERROR_MESSAGE
       end
       GCECredentials.new
     end
-
-    module_function :get_application_default
   end
 end
diff --git a/lib/googleauth/compute_engine.rb b/lib/googleauth/compute_engine.rb
index c067835..08ecf66 100644
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -35,16 +35,16 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NO_METADATA_SERVER_ERROR = <<-ERROR.freeze
-Error code 404 trying to get security access token
-from Compute Engine metadata for the default service account. This
-may be because the virtual machine instance does not have permission
-scopes specified.
-ERROR
-    UNEXPECTED_ERROR_SUFFIX = <<-ERROR.freeze
-trying to get security access token from Compute Engine metadata for
-the default service account
-ERROR
+    NO_METADATA_SERVER_ERROR = <<~ERROR.freeze
+      Error code 404 trying to get security access token
+      from Compute Engine metadata for the default service account. This
+      may be because the virtual machine instance does not have permission
+      scopes specified.
+    ERROR
+    UNEXPECTED_ERROR_SUFFIX = <<~ERROR.freeze
+      trying to get security access token from Compute Engine metadata for
+      the default service account
+    ERROR
 
     # Extends Signet::OAuth2::Client so that the auth token is obtained from
     # the GCE metadata server.
@@ -59,22 +59,16 @@ ERROR
         extend Memoist
 
         # Detect if this appear to be a GCE instance, by checking if metadata
-        # is available
+        # is available.
         def on_gce? options = {}
+          # TODO: This should use google-cloud-env instead.
           c = options[:connection] || Faraday.default_connection
-          resp = c.get COMPUTE_CHECK_URI do |req|
-            # Comment from: oauth2client/client.py
-            #
-            # Note: the explicit `timeout` below is a workaround. The underlying
-            # issue is that resolving an unknown host on some networks will take
-            # 20-30 seconds; making this timeout short fixes the issue, but
-            # could lead to false negatives in the event that we are on GCE, but
-            # the metadata resolution was particularly slow. The latter case is
-            # "unlikely".
-            req.options.timeout = 0.1
+          headers = { "Metadata-Flavor" => "Google" }
+          resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|
+            req.options.timeout = 1.0
+            req.options.open_timeout = 0.1
           end
           return false unless resp.status == 200
-          return false unless resp.headers.key? "Metadata-Flavor"
           resp.headers["Metadata-Flavor"] == "Google"
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
           false
diff --git a/lib/googleauth/credentials.rb b/lib/googleauth/credentials.rb
index 4db5954..520371d 100644
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -257,6 +257,9 @@ module Google
         CredentialsLoader.warn_if_cloud_sdk_credentials @client.client_id
         @project_id ||= CredentialsLoader.load_gcloud_project_id
         @client.fetch_access_token!
+        @env_vars = nil
+        @paths = nil
+        @scope = nil
       end
       # rubocop:enable Metrics/AbcSize
 
diff --git a/lib/googleauth/credentials_loader.rb b/lib/googleauth/credentials_loader.rb
index c2ab551..79bee2c 100644
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -64,13 +64,13 @@ module Google
       CLOUD_SDK_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.app"\
         "s.googleusercontent.com".freeze
 
-      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated "\
-        "using end user credentials from Google Cloud SDK. We recommend that "\
-        "most server applications use service accounts instead. If your "\
-        "application continues to use end user credentials from Cloud SDK, "\
-        'you might receive a "quota exceeded" or "API not enabled" error. For'\
-        " more information about service accounts, see "\
-        "https://cloud.google.com/docs/authentication/.".freeze
+      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated using end user "\
+        "credentials from Google Cloud SDK. We recommend that most server applications use "\
+        "service accounts instead. If your application continues to use end user credentials "\
+        'from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For '\
+        "more information about service accounts, see "\
+        "https://cloud.google.com/docs/authentication/. To suppress this message, set the "\
+        "GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS environment variable.".freeze
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -163,11 +163,13 @@ module Google
         raise "#{SYSTEM_DEFAULT_ERROR}: #{e}"
       end
 
+      module_function
+
       # Issues warning if cloud sdk client id is used
       def warn_if_cloud_sdk_credentials client_id
+        return if ENV["GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS"]
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
-      module_function :warn_if_cloud_sdk_credentials
 
       # Finds project_id from gcloud CLI configuration
       def load_gcloud_project_id
@@ -179,7 +181,6 @@ module Google
       rescue StandardError
         nil
       end
-      module_function :load_gcloud_project_id
 
       private
 
@@ -193,15 +194,13 @@ module Google
       end
 
       def service_account_env_vars?
-        [PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR].all? do |key|
-          ENV[key] && !ENV[key].empty?
-        end
+        ([PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR] - ENV.keys).empty? &&
+          !ENV.to_h.fetch_values(PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR).join(" ").empty?
       end
 
       def authorized_user_env_vars?
-        [CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR].all? do |key|
-          ENV[key] && !ENV[key].empty?
-        end
+        ([CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR] - ENV.keys).empty? &&
+          !ENV.to_h.fetch_values(CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR).join(" ").empty?
       end
     end
   end
diff --git a/lib/googleauth/signet.rb b/lib/googleauth/signet.rb
index 197367f..db0dfa8 100644
--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -66,7 +66,7 @@ module Signet
       end
 
       def on_refresh &block
-        @refresh_listeners ||= []
+        @refresh_listeners = [] unless defined? @refresh_listeners
         @refresh_listeners << block
       end
 
@@ -84,15 +84,16 @@ module Signet
       end
 
       def notify_refresh_listeners
-        listeners = @refresh_listeners || []
+        listeners = defined?(@refresh_listeners) ? @refresh_listeners : []
         listeners.each do |block|
           block.call self
         end
       end
 
       def build_default_connection
-        return nil unless defined?(@connection_info)
-        if @connection_info.respond_to? :call
+        if !defined?(@connection_info)
+          nil
+        elsif @connection_info.respond_to? :call
           @connection_info.call
         else
           @connection_info
diff --git a/lib/googleauth/user_authorizer.rb b/lib/googleauth/user_authorizer.rb
index 0526dad..59f4647 100644
--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -129,8 +129,8 @@ module Google
         data = MultiJson.load saved_token
 
         if data.fetch("client_id", @client_id.id) != @client_id.id
-          raise sprintf(MISMATCHED_CLIENT_ID_ERROR,
-                        data["client_id"], @client_id.id)
+          raise format(MISMATCHED_CLIENT_ID_ERROR,
+                       data["client_id"], @client_id.id)
         end
 
         credentials = UserRefreshCredentials.new(
diff --git a/lib/googleauth/version.rb b/lib/googleauth/version.rb
index 89885e1..def1a08 100644
--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.9.0".freeze
+    VERSION = "0.10.0".freeze
   end
 end
diff --git a/lib/googleauth/web_user_authorizer.rb b/lib/googleauth/web_user_authorizer.rb
index 1cb9fb5..545506a 100644
--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -171,7 +171,7 @@ module Google
         options[:state] = MultiJson.dump(state.merge(
                                            SESSION_ID_KEY  => request.session[XSRF_KEY],
                                            CURRENT_URI_KEY => redirect_to
-        ))
+                                         ))
         options[:base_url] = request.url
         super options
       end
diff --git a/spec/googleauth/compute_engine_spec.rb b/spec/googleauth/compute_engine_spec.rb
index 6429405..9416757 100644
--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -97,6 +97,7 @@ describe Google::Auth::GCECredentials do
   describe "#on_gce?" do
     it "should be true when Metadata-Flavor is Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(true)
@@ -105,6 +106,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false when Metadata-Flavor is not Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
@@ -113,6 +115,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false if the response is not 200" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  404,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
diff --git a/spec/googleauth/credentials_spec.rb b/spec/googleauth/credentials_spec.rb
index 3cb2183..14a6dd3 100644
--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -128,6 +128,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -164,6 +165,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -198,6 +200,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -232,6 +235,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -310,6 +314,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -345,6 +350,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -378,6 +384,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -411,6 +418,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }

```

</details>

This pull request was generated using releasetool.