### PR TITLE
add v to version in docs url to keep consistent with other ruby libraries

### DIFF
--- a/rakelib/repo_metadata.rb
+++ b/rakelib/repo_metadata.rb
@@ -26,7 +26,7 @@ class RepoMetadata
     require_relative "../lib/googleauth/version.rb"
 
     @data.delete_if { |k, _| !allowed_fields.include?(k) }
-    @data["version"] = Google::Auth::VERSION
+    @data["version"] = "v#{Google::Auth::VERSION}"
   end
 
   def [] key


### PR DESCRIPTION
Change https://googleapis.dev/ruby/googleauth/0.10.0/index.html to https://googleapis.dev/ruby/googleauth/v0.10.0/index.html