### PR TITLE
Honor token_uri provided in JSON key files

### DIFF
--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -34,12 +34,12 @@ module Google
     # JsonKeyReader contains the behaviour used to read private key and
     # client email fields from the service account
     module JsonKeyReader
-      def read_json_key json_key_io
-        json_key = MultiJson.load json_key_io.read
-        raise "missing client_email" unless json_key.key? "client_email"
-        raise "missing private_key" unless json_key.key? "private_key"
-        project_id = json_key["project_id"]
-        [json_key["private_key"], json_key["client_email"], project_id]
+      def read_json_key json_key_io, required_fields = []
+        MultiJson.load(json_key_io.read).tap do |json_key|
+          required_fields.each do |key|
+            raise "the json is missing the #{key} field" unless json_key.key? key
+          end
+        end
       end
     end
   end

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -59,7 +59,10 @@ module Google
       def self.make_creds options = {}
         json_key_io, scope = options.values_at :json_key_io, :scope
         if json_key_io
-          private_key, client_email, project_id = read_json_key json_key_io
+          json_key = read_json_key(json_key_io, %w[client_email private_key])
+          private_key = json_key["private_key"]
+          client_email = json_key["client_email"]
+          project_id = json_key["project_id"]
         else
           private_key = unescape ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
@@ -151,8 +154,10 @@ module Google
       def initialize options = {}
         json_key_io = options[:json_key_io]
         if json_key_io
-          @private_key, @issuer, @project_id =
-            self.class.read_json_key json_key_io
+          json_key = self.class.read_json_key(json_key_io, %w[client_email private_key])
+          @private_key = json_key["private_key"]
+          @issuer = json_key["client_email"]
+          @project_id = json_key["project_id"]
         else
           @private_key = ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           @issuer = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -63,15 +63,17 @@ module Google
           private_key = json_key["private_key"]
           client_email = json_key["client_email"]
           project_id = json_key["project_id"]
+          token_uri = json_key["token_uri"]
         else
           private_key = unescape ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
         end
         project_id ||= CredentialsLoader.load_gcloud_project_id
+        token_uri ||= TOKEN_CRED_URI
 
-        new(token_credential_uri: TOKEN_CRED_URI,
-            audience:             TOKEN_CRED_URI,
+        new(token_credential_uri: token_uri,
+            audience:             token_uri,
             scope:                scope,
             issuer:               client_email,
             signing_key:          OpenSSL::PKey::RSA.new(private_key),
@@ -158,6 +160,8 @@ module Google
           @private_key = json_key["private_key"]
           @issuer = json_key["client_email"]
           @project_id = json_key["project_id"]
+          @token_credential_uri = json_key["token_uri"] || TOKEN_CRED_URI
+          @audience = json_key["token_uri"] || TOKEN_CRED_URI
         else
           @private_key = ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           @issuer = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -67,7 +67,7 @@ module Google
           "project_id"    => ENV[CredentialsLoader::PROJECT_ID_VAR]
         }
 
-        new(token_credential_uri: TOKEN_CRED_URI,
+        new(token_credential_uri: user_creds["token_uri"],
             client_id:            user_creds["client_id"],
             client_secret:        user_creds["client_secret"],
             refresh_token:        user_creds["refresh_token"],

--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -41,6 +41,7 @@ describe Google::Auth::Credentials, :private do
       "client_email"   => "credz-testabc1234567890xyz@developer.gserviceaccount.com",
       "client_id"      => "credz-testabc1234567890xyz.apps.googleusercontent.com",
       "type"           => "service_account",
+      "token_uri"      => "https://oauth2.googleapis.com/token",
       "project_id"     => "a_project_id"
     }
   end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -117,6 +117,7 @@ describe Google::Auth::ServiceAccountCredentials do
       client_email:   client_email,
       client_id:      "app.apps.googleusercontent.com",
       type:           "service_account",
+      token_uri:      "https://oauth2.googleapis.com/token",
       project_id:     "a_project_id"
     }
   end
@@ -140,7 +141,7 @@ describe Google::Auth::ServiceAccountCredentials do
                                    @key.public_key, true,
                                    algorithm: "RS256")
     end
-    stub_request(:post, "https://www.googleapis.com/oauth2/v4/token")
+    stub_request(:post, cred_json[:token_uri])
       .with(body: hash_including(
         "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer"
       ),
@@ -162,6 +163,20 @@ describe Google::Auth::ServiceAccountCredentials do
     end
 
     it_behaves_like "jwt header auth"
+  end
+
+  context "when token_uri is provided in the JSON" do
+    it "sets token_credential_uri based on the JSON" do
+      expect(@client.token_credential_uri.to_s).to eq(cred_json[:token_uri])
+    end
+  end
+
+  context "when token_uri is not provided in the JSON" do
+    let(:cred_json) { super().tap { |j| j.delete(:token_uri) } }
+
+    it "sets token_credential_uri to a default value" do
+      expect(@client.token_credential_uri.to_s).to eq(ServiceAccountCredentials::TOKEN_CRED_URI)
+    end
   end
 
   describe "#from_env" do


### PR DESCRIPTION
Other implementations, such as google-auth-library-python and google-auth-library-java, read the token_uri provided in a JSON key file and use it to initialize the OAuth2 client.

This library ignored the token_uri and always used a fixed value set in Google::Auth::ServiceAccountCredentials::TOKEN_CRED_URI.

