### PR TITLE
Update faraday

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.platform      = Gem::Platform::RUBY
   gem.required_ruby_version = ">= 2.4.0"
 
-  gem.add_dependency "faraday", "~> 0.12"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"


### PR DESCRIPTION
[Faraday got updated](https://github.com/lostisland/faraday/pull/1101) and [we over at manageiq](https://github.com/ManageIQ/manageiq/issues/19760) were hoping maybe that you all might be amenable to letting people update so we can support ruby 2.7.

This is a pretty significant change since v0.12 is from April 01, 2017. 

~~It's WIP because I don't think this can get in unless [signet also gets an upgrade, though it's open.](https://github.com/googleapis/signet/pull/159)~~

Thanks!