### PR TITLE
feat: Support for ID token credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ platforms :jruby do
   end
 end
 
+gem "faraday", "~> 0.17"
 gem "gems", "~> 1.2"

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "~> 0.12"
+  gem.add_dependency "signet", "~> 0.14"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -84,13 +84,10 @@ module Google
       def fetch_access_token options = {}
         c = options[:connection] || Faraday.default_connection
         retry_with_error do
+          uri = target_audience ? COMPUTE_ID_TOKEN_URI : COMPUTE_AUTH_TOKEN_URI
+          query = target_audience ? { "audience" => target_audience, "format" => "full" } : nil
           headers = { "Metadata-Flavor" => "Google" }
-          resp =
-            if target_audience
-              c.get COMPUTE_ID_TOKEN_URI, { "audience" => target_audience }, headers
-            else
-              c.get COMPUTE_AUTH_TOKEN_URI, nil, headers
-            end
+          resp = c.get uri, query, headers
           case resp.status
           when 200
             content_type = resp.headers["content-type"]

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -399,6 +399,10 @@ module Google
         options["scope"] ||= self.class.scope
         options["target_audience"] ||= self.class.target_audience
 
+        if !Array(options["scope"]).empty? && options["target_audience"]
+          raise ArgumentError, "Cannot specify both scope and target_audience"
+        end
+
         needs_scope = options["target_audience"].nil?
         # client options for initializing signet client
         { token_credential_uri: options["token_credential_uri"],

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -47,6 +47,8 @@ module Google
       # The default target audience ID to be used when none is provided during initialization.
       AUDIENCE = "https://oauth2.googleapis.com/token".freeze
 
+      @audience = @scope = @target_audience = @env_vars = @paths = nil
+
       ##
       # The default token credential URI to be used when none is provided during initialization.
       # The URI is the authorization server's HTTP endpoint capable of issuing tokens and
@@ -97,19 +99,24 @@ module Google
       # A scope is an access range defined by the authorization server.
       # The scope can be a single value or a list of values.
       #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
       # @return [String, Array<String>]
       #
       def self.scope
         return @scope unless @scope.nil?
 
-        tmp_scope = []
-        # Pull in values is the SCOPE constant exists.
-        tmp_scope << const_get(:SCOPE) if const_defined? :SCOPE
-        tmp_scope.flatten.uniq
+        Array(const_get(:SCOPE)).flatten.uniq if const_defined? :SCOPE
       end
 
       ##
       # Sets the default scope to be used when none is provided during initialization.
+      #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
       #
       # @param [String, Array<String>] new_scope
       # @return [String, Array<String>]
@@ -117,6 +124,34 @@ module Google
       def self.scope= new_scope
         new_scope = Array new_scope unless new_scope.nil?
         @scope = new_scope
+      end
+
+      ##
+      # The default final target audience for ID tokens, to be used when none
+      # is provided during initialization.
+      #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
+      # @return [String]
+      #
+      def self.target_audience
+        @target_audience
+      end
+
+      ##
+      # Sets the default final target audience for ID tokens, to be used when none
+      # is provided during initialization.
+      #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
+      # @param [String] new_target_audience
+      #
+      def self.target_audience= new_target_audience
+        @target_audience = new_target_audience
       end
 
       ##
@@ -208,6 +243,9 @@ module Google
       #   @return [String, Array<String>] The scope for this client. A scope is an access range
       #     defined by the authorization server. The scope can be a single value or a list of values.
       #
+      # @!attribute [r] target_audience
+      #   @return [String] The final target audience for ID tokens returned by this credential.
+      #
       # @!attribute [r] issuer
       #   @return [String] The issuer ID associated with this client.
       #
@@ -220,7 +258,7 @@ module Google
       #
       def_delegators :@client,
                      :token_credential_uri, :audience,
-                     :scope, :issuer, :signing_key, :updater_proc
+                     :scope, :issuer, :signing_key, :updater_proc, :target_audience
 
       ##
       # Creates a new Credentials instance with the provided auth credentials, and with the default
@@ -319,7 +357,8 @@ module Google
       # @private Lookup Credentials using Google::Auth.get_application_default.
       def self.from_application_default options
         scope = options[:scope] || self.scope
-        client = Google::Auth.get_application_default scope
+        auth_opts = { target_audience: options[:target_audience] || target_audience }
+        client = Google::Auth.get_application_default scope, auth_opts
         new client, options
       end
 
@@ -358,11 +397,14 @@ module Google
         options["token_credential_uri"] ||= self.class.token_credential_uri
         options["audience"] ||= self.class.audience
         options["scope"] ||= self.class.scope
+        options["target_audience"] ||= self.class.target_audience
 
+        needs_scope = options["target_audience"].nil?
         # client options for initializing signet client
         { token_credential_uri: options["token_credential_uri"],
           audience:             options["audience"],
-          scope:                Array(options["scope"]),
+          scope:                (needs_scope ? Array(options["scope"]) : nil),
+          target_audience:      options["target_audience"],
           issuer:               options["client_email"],
           signing_key:          OpenSSL::PKey::RSA.new(options["private_key"]) }
       end
@@ -376,6 +418,7 @@ module Google
       def update_from_hash hash, options
         hash = stringify_hash_keys hash
         hash["scope"] ||= options[:scope]
+        hash["target_audience"] ||= options[:target_audience]
         @project_id ||= (hash["project_id"] || hash["project"])
         @quota_project_id ||= hash["quota_project_id"]
         @client = init_client hash, options
@@ -385,6 +428,7 @@ module Google
         verify_keyfile_exists! path
         json = JSON.parse ::File.read(path)
         json["scope"] ||= options[:scope]
+        json["target_audience"] ||= options[:target_audience]
         @project_id ||= (json["project_id"] || json["project"])
         @quota_project_id ||= json["quota_project_id"]
         @client = init_client json, options

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -59,6 +59,8 @@ module Google
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
         json_key_io, scope, target_audience = options.values_at :json_key_io, :scope, :target_audience
+        raise ArgumentError, "Cannot specify both scope and target_audience" if scope && target_audience
+
         if json_key_io
           private_key, client_email, project_id, quota_project_id = read_json_key json_key_io
         else

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -58,7 +58,7 @@ module Google
       # @param json_key_io [IO] an IO from which the JSON key can be read
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
-        json_key_io, scope = options.values_at :json_key_io, :scope
+        json_key_io, scope, target_audience = options.values_at :json_key_io, :scope, :target_audience
         if json_key_io
           private_key, client_email, project_id, quota_project_id = read_json_key json_key_io
         else
@@ -72,6 +72,7 @@ module Google
         new(token_credential_uri: TOKEN_CRED_URI,
             audience:             TOKEN_CRED_URI,
             scope:                scope,
+            target_audience:      target_audience,
             issuer:               client_email,
             signing_key:          OpenSSL::PKey::RSA.new(private_key),
             project_id:           project_id,

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -48,8 +48,9 @@ module Signet
       def apply! a_hash, opts = {}
         # fetch the access token there is currently not one, or if the client
         # has expired
-        fetch_access_token! opts if access_token.nil? || expires_within?(60)
-        a_hash[AUTH_METADATA_KEY] = "Bearer #{access_token}"
+        token_type = target_audience ? :id_token : :access_token
+        fetch_access_token! opts if send(token_type).nil? || expires_within?(60)
+        a_hash[AUTH_METADATA_KEY] = "Bearer #{send token_type}"
       end
 
       # Returns a clone of a_hash updated with the authentication token

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -57,7 +57,7 @@ module Google
       # @param json_key_io [IO] an IO from which the JSON key can be read
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
-        json_key_io, scope = options.values_at :json_key_io, :scope
+        json_key_io, scope, target_audience = options.values_at :json_key_io, :scope, :target_audience
         user_creds = read_json_key json_key_io if json_key_io
         user_creds ||= {
           "client_id"     => ENV[CredentialsLoader::CLIENT_ID_VAR],
@@ -71,7 +71,8 @@ module Google
             client_secret:        user_creds["client_secret"],
             refresh_token:        user_creds["refresh_token"],
             project_id:           user_creds["project_id"],
-            scope:                scope)
+            scope:                scope,
+            target_audience:      target_audience)
           .configure_connection(options)
       end
 

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -57,7 +57,7 @@ module Google
       # @param json_key_io [IO] an IO from which the JSON key can be read
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
-        json_key_io, scope, target_audience = options.values_at :json_key_io, :scope, :target_audience
+        json_key_io, scope = options.values_at :json_key_io, :scope
         user_creds = read_json_key json_key_io if json_key_io
         user_creds ||= {
           "client_id"     => ENV[CredentialsLoader::CLIENT_ID_VAR],
@@ -71,8 +71,7 @@ module Google
             client_secret:        user_creds["client_secret"],
             refresh_token:        user_creds["refresh_token"],
             project_id:           user_creds["project_id"],
-            scope:                scope,
-            target_audience:      target_audience)
+            scope:                scope)
           .configure_connection(options)
       end
 

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -45,26 +45,37 @@ shared_examples "apply/apply! are OK" do
   # auth client
   describe "#fetch_access_token" do
     let(:token) { "1/abcdef1234567890" }
-    let :stub do
+    let :access_stub do
       make_auth_stubs access_token: token
+    end
+    let :id_stub do
+      make_auth_stubs id_token: token
     end
 
     it "should set access_token to the fetched value" do
-      stub
+      access_stub
       @client.fetch_access_token!
       expect(@client.access_token).to eq(token)
-      expect(stub).to have_been_requested
+      expect(access_stub).to have_been_requested
+    end
+
+    it "should set id_token to the fetched value" do
+      skip unless @id_client
+      id_stub
+      @id_client.fetch_access_token!
+      expect(@id_client.id_token).to eq(token)
+      expect(id_stub).to have_been_requested
     end
 
     it "should notify refresh listeners after updating" do
-      stub
+      access_stub
       expect do |b|
         @client.on_refresh(&b)
         @client.fetch_access_token!
       end.to yield_with_args(have_attributes(
                                access_token: "1/abcdef1234567890"
                              ))
-      expect(stub).to have_been_requested
+      expect(access_stub).to have_been_requested
     end
   end
 

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -38,7 +38,7 @@ require "spec_helper"
 
 describe Google::Auth::GCECredentials do
   MD_ACCESS_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token".freeze
-  MD_ID_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://pubsub.googleapis.com/".freeze
+  MD_ID_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://pubsub.googleapis.com/&format=full".freeze
   GCECredentials = Google::Auth::GCECredentials
 
   before :example do

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -64,11 +64,11 @@ describe Google::Auth::UserRefreshCredentials do
     )
   end
 
-  def make_auth_stubs opts = {}
-    access_token = opts[:access_token] || ""
-    body = MultiJson.dump("access_token" => access_token,
-                          "token_type"   => "Bearer",
-                          "expires_in"   => 3600)
+  def make_auth_stubs opts
+    body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
+    body_fields["access_token"] = opts[:access_token] if opts[:access_token]
+    body_fields["id_token"] = opts[:id_token] if opts[:id_token]
+    body = MultiJson.dump body_fields
     stub_request(:post, "https://oauth2.googleapis.com/token")
       .with(body: hash_including("grant_type" => "refresh_token"))
       .to_return(body:    body,

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -65,10 +65,10 @@ describe Google::Auth::UserRefreshCredentials do
   end
 
   def make_auth_stubs opts
-    body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
-    body_fields["access_token"] = opts[:access_token] if opts[:access_token]
-    body_fields["id_token"] = opts[:id_token] if opts[:id_token]
-    body = MultiJson.dump body_fields
+    access_token = opts[:access_token] || ""
+    body = MultiJson.dump("access_token" => access_token,
+                          "token_type"   => "Bearer",
+                          "expires_in"   => 3600)
     stub_request(:post, "https://oauth2.googleapis.com/token")
       .with(body: hash_including("grant_type" => "refresh_token"))
       .to_return(body:    body,


### PR DESCRIPTION
Supports:
* Fetching ID tokens based on service account keys.
* Fetching ID tokens from the compute engine metadata service.
* Using ID tokens in outgoing auth headers.

ID tokens credentials are generally treated similarly to access tokens. To initialize a credentials object that uses ID tokens instead of access tokens, provide a `target_audience` instead of a `scope` when initializing the credentials. For example:

```ruby
# Access tokens:
access_token_creds = Google::Auth::Credentials.default \
    scope: "https://www.googleapis.com/auth/cloud-platform"
id_token_creds = Google::Auth::Credentials.default \
    target_audience: "https://example.com/"
```

Then, ID tokens can be applied to headers in the same way:

```ruby
headers = { "Content-Type" => "application/json" }
access_token_creds.client.apply! headers
# or
id_token_creds.client.apply! headers

# headers now includes "Authorization" => "Bearer: sometoken12345"
```

ID tokens also use the same auto-refresh mechanism used for access tokens.

Note: This PR depends on an update to signet. (See https://github.com/googleapis/signet/pull/168). Hence, we do not expect CI to pass until signet has been updated and released.