### PR TITLE
Release google-auth-library-ruby 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.12.0 / 2020-04-08
+
+* Support for ID token credentials.
+* Support reading quota_id_project from service account credentials.
+
 ### 0.11.0 / 2020-02-24
 
 * Support Faraday 1.x.

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.11.0".freeze
+    VERSION = "0.12.0".freeze
   end
 end


### PR DESCRIPTION
* Support for ID token credentials.
* Support reading quota_id_project from service account credentials.

<details><summary>Commits since previous release</summary><pre><code>commit c7f82f29f8547acd64b94c524c845cb9dd490e04
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Apr 7 17:19:29 2020 -0700

    feat: Support for ID token credentials.

commit 5b6ef36a670210e49e38ea93e1b0a25ce3616242
Author: David Supplee <dwsupplee@gmail.com>
Date:   Mon Mar 16 15:33:17 2020 +0000

    chore: update github url

commit 61c1e64d5b39fec80f1adf758caf32a0239bb262
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Mar 6 16:56:16 2020 -0800

    feat: read quota_project_id from credentials

commit 41f033361410e86f2228ab91a5619b69413e236d
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Feb 24 15:18:29 2020 -0800

    Release google-auth-library-ruby 0.11.0

commit de8e9e42afc74fef211147154fd366f0f2c69757
Author: d-m-u <16326669+d-m-u@users.noreply.github.com>
Date:   Mon Feb 24 17:23:05 2020 -0500

    feat: support Faraday 1.x

commit d80900156a02f5d79666fe9a11fb610a1443f34c
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Dec 2 10:11:13 2019 -0700

    Add whitelisted 'postmessage' to valid redirect URIs (#249)
    
    closes: #92

commit 4928d44072bec6645251bddf19b06810734f877a
Author: Graham Paye <paye@google.com>
Date:   Tue Oct 29 16:08:50 2019 -0700

    add v to version in docs url (#246)

commit b33b25c3fb76f1807d4790ef8b72ed783da8e99c
Author: Graham Paye <paye@google.com>
Date:   Thu Oct 17 18:12:43 2019 -0700

    chore: use docker images from google-cloud-ruby (#244)

commit 584ad57d7d72d9ffa395daa1dde4c48e04ab3c99
Author: Graham Paye <paye@google.com>
Date:   Fri Oct 11 16:39:41 2019 -0700

    chore: run linkinator on merges to master (#243)

commit a6082d158b61b2830322faf15c02d69cbd3ccff5
Author: Graham Paye <paye@google.com>
Date:   Fri Oct 11 10:56:55 2019 -0700

    chore: publish to googleapis.dev on release (#242)

commit 6be995d29a87d408e33e4da0ec2c1d95f7baa306
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 12:16:27 2019 -0700

    Release google-auth-library-ruby 0.10.0 (#240)
    
    Note: This release now requires Ruby 2.4 or later
    
    * Increase metadata timeout to improve reliability in some hosting environments
    * Support an environment variable to suppress Cloud SDK credentials warnings
    * Make the header check case insensitive
    * Set instance variables at initialization to avoid spamming warnings
    * Pass "Metadata-Flavor" header to metadata server when checking for GCE

commit fe4220244c196a626d43093e6d806b02af983c3b
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 11:25:44 2019 -0700

    Require Ruby 2.4 and Signet 0.12 (#236)

commit 5523a75fc379d2d4554e7edd80490454181b6a69
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 10:55:44 2019 -0700

    Fixes to release scripts (#238)

commit 41bb5f13b2053e24b7b176a704a14d26daf80125
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Oct 8 11:33:03 2019 -0700

    fix: Increase metadata timeout, matching the logic in google-cloud-env

commit 9c46b3b049cd24c2541e9808d4f2b7e0e6e7f333
Author: Cera <ceralena.davies@gmail.com>
Date:   Wed Oct 9 04:00:36 2019 +1100

    feat: Support an environment variable to suppress Cloud SDK credentials warnings

commit be7599f53635b8b9ecc1b53bfce84ed38e083cab
Author: Abdulrahman Khalil <a.skhalil93@gmail.com>
Date:   Tue Oct 8 05:44:54 2019 +0300

    Make the header check case insensitive (#223)

commit 356d8fcaa89e0f0ac4626b62469189cd7b787a50
Author: Graham Paye <paye@google.com>
Date:   Tue Sep 24 08:05:26 2019 -0700

    chore: set os and trampoline_script (#234)

commit 2cd6af174d727a110cd4e874793ec9d93c91c3a2
Author: Ling Huang <qingling128@users.noreply.github.com>
Date:   Thu Aug 15 21:46:38 2019 -0400

    fix: Set instance variables at initialization to avoid spamming rake warnings

commit efb9b7897a696f54d58c0d828eb91c59cfa171af
Author: Spring_MT <today.is.sky.blue.sky@gmail.com>
Date:   Wed Aug 14 02:28:08 2019 +0900

    fix: Pass "Metadata-Flavor" header to metadata server when checking for GCE

commit 464d2650d0536778200968fb5374972d36d632b3
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Aug 5 18:55:27 2019 -0700

    Prepare for v0.10 development
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/.kokoro/continuous/linux.cfg b/.kokoro/continuous/linux.cfg
index e7a371d..9346dce 100644
--- a/.kokoro/continuous/linux.cfg
+++ b/.kokoro/continuous/linux.cfg
@@ -3,13 +3,23 @@
 build_file: "google-auth-library-ruby/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
-# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/ruby-multi
+# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/multi
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi"
 }
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
diff --git a/.kokoro/continuous/osx.cfg b/.kokoro/continuous/osx.cfg
index b1c6c3b..55fdacf 100644
--- a/.kokoro/continuous/osx.cfg
+++ b/.kokoro/continuous/osx.cfg
@@ -1,3 +1,8 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "google-auth-library-ruby/.kokoro/osx.sh"
+
+env_vars: {
+    key: "OS"
+    value: "osx"
+}
diff --git a/.kokoro/continuous/post.cfg b/.kokoro/continuous/post.cfg
new file mode 100644
index 0000000..9e57494
--- /dev/null
+++ b/.kokoro/continuous/post.cfg
@@ -0,0 +1,30 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "google-auth-library-ruby/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/multi-node
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-auth-library-ruby/.kokoro/build.sh"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
+
+env_vars: {
+    key: "JOB_TYPE"
+    value: "post"
+}
diff --git a/.kokoro/continuous/windows.cfg b/.kokoro/continuous/windows.cfg
index ff953f8..b2dd2cc 100644
--- a/.kokoro/continuous/windows.cfg
+++ b/.kokoro/continuous/windows.cfg
@@ -13,7 +13,17 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.bat"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_windows.py"
+}
+
 env_vars: {
     key: "REPO_DIR"
     value: "google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "OS"
+    value: "windows"
+}
diff --git a/.kokoro/presubmit/linux.cfg b/.kokoro/presubmit/linux.cfg
index 9ea4ac3..dbf849e 100644
--- a/.kokoro/presubmit/linux.cfg
+++ b/.kokoro/presubmit/linux.cfg
@@ -5,10 +5,20 @@ build_file: "google-auth-library-ruby/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi"
 }
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
diff --git a/.kokoro/presubmit/osx.cfg b/.kokoro/presubmit/osx.cfg
index b1c6c3b..55fdacf 100644
--- a/.kokoro/presubmit/osx.cfg
+++ b/.kokoro/presubmit/osx.cfg
@@ -1,3 +1,8 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "google-auth-library-ruby/.kokoro/osx.sh"
+
+env_vars: {
+    key: "OS"
+    value: "osx"
+}
diff --git a/.kokoro/presubmit/windows.cfg b/.kokoro/presubmit/windows.cfg
index ff953f8..b2dd2cc 100644
--- a/.kokoro/presubmit/windows.cfg
+++ b/.kokoro/presubmit/windows.cfg
@@ -13,7 +13,17 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.bat"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_windows.py"
+}
+
 env_vars: {
     key: "REPO_DIR"
     value: "google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "OS"
+    value: "windows"
+}
diff --git a/.kokoro/release.cfg b/.kokoro/release.cfg
index 2ec59ed..f4f543e 100644
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -17,6 +17,37 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
 # Download resources for system tests (service account key, etc.)
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
 
@@ -29,7 +60,7 @@ build_file: "google-auth-library-ruby/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/google-cloud-ruby/ruby-release"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
 }
 
 env_vars: {
@@ -37,6 +68,11 @@ env_vars: {
     value: "github/google-auth-library-ruby/.kokoro/build.sh"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
 env_vars: {
     key: "JOB_TYPE"
     value: "release"
@@ -51,3 +87,8 @@ env_vars: {
     key: "REPO_DIR"
     value: "github/google-auth-library-ruby"
 }
+
+env_vars: {
+    key: "PACKAGE"
+    value: "googleauth"
+}
diff --git a/.repo-metadata.json b/.repo-metadata.json
new file mode 100644
index 0000000..2ee3eb3
--- /dev/null
+++ b/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "googleauth",
+    "language": "ruby",
+    "distribution-name": "googleauth"
+}
\ No newline at end of file
diff --git a/.rubocop.yml b/.rubocop.yml
index bda4f78..67285fc 100644
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,42 +1,17 @@
+inherit_gem:
+  google-style: google-style.yml
+
 AllCops:
   Exclude:
     - "spec/**/*"
     - "Rakefile"
-
-Metrics/AbcSize:
-  Max: 25
+    - "rakelib/**/*"
+Metrics/ClassLength:
+  Max: 200
+Metrics/ModuleLength:
+  Max: 110
 Metrics/BlockLength:
   Exclude:
     - "googleauth.gemspec"
-Metrics/CyclomaticComplexity:
-  Max: 8
-Metrics/PerceivedComplexity:
-  Max: 8
-Metrics/LineLength:
-  Max: 120
-Metrics/MethodLength:
-  Max: 21
-Metrics/ModuleLength:
-  Max: 150
-Metrics/ClassLength:
-  Enabled: false
-Layout/IndentHeredoc:
-  Enabled: false
-Style/FormatString:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
-Style/PercentLiteralDelimiters: # Contradicting rule
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/SymbolArray: # Undefined syntax in Ruby 1.9.3
-  Enabled: false
-Style/MethodDefParentheses:
-  Enabled: false
-Style/WordArray:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/RescueModifier:
+Style/SafeNavigation:
   Enabled: false
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 3a3d6de..5bf9f50 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### 0.11.0 / 2020-02-24
+
+* Support Faraday 1.x.
+* Allow special "postmessage" value for redirect_uri.
+
+### 0.10.0 / 2019-10-09
+
+Note: This release now requires Ruby 2.4 or later
+
+* Increase metadata timeout to improve reliability in some hosting environments
+* Support an environment variable to suppress Cloud SDK credentials warnings
+* Make the header check case insensitive
+* Set instance variables at initialization to avoid spamming warnings
+* Pass "Metadata-Flavor" header to metadata server when checking for GCE
+
 ### 0.9.0 / 2019-08-05
 
 * Restore compatibility with Ruby 2.0. This is the last release that will work on end-of-lifed versions of Ruby. The 0.10 release will require Ruby 2.4 or later.
diff --git a/Gemfile b/Gemfile
index 9bc8d98..2ff988b 100755
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,12 @@ group :development do
   gem "coveralls", "~> 0.7"
   gem "fakefs", "~> 0.6"
   gem "fakeredis", "~> 0.5"
+  gem "google-style", "~> 1.24.0"
   gem "logging", "~> 2.0"
   gem "rack-test", "~> 0.6"
   gem "rake", "~> 10.0"
   gem "redis", "~> 3.2"
   gem "rspec", "~> 3.0"
-  gem "rubocop", ">= 0.41", "< 0.50"
   gem "simplecov", "~> 0.9"
   gem "sinatra"
   gem "webmock", "~> 1.21"
@@ -23,3 +23,6 @@ platforms :jruby do
   group :development do
   end
 end
+
+gem "faraday", "~> 0.17"
+gem "gems", "~> 1.2"
diff --git a/README.md b/README.md
index 381a5d6..5eb3ec9 100644
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Google Auth Library for Ruby
 
 <dl>
-  <dt>Homepage</dt><dd><a href="http://www.github.com/google/google-auth-library-ruby">http://www.github.com/google/google-auth-library-ruby</a></dd>
+  <dt>Homepage</dt><dd><a href="http://www.github.com/googleapis/google-auth-library-ruby">http://www.github.com/googleapis/google-auth-library-ruby</a></dd>
   <dt>Authors</dt><dd><a href="mailto:temiola@google.com">Tim Emiola</a></dd>
   <dt>Copyright</dt><dd>Copyright © 2015 Google, Inc.</dd>
   <dt>License</dt><dd>Apache 2.0</dd>
 </dl>
 
 [![Gem Version](https://badge.fury.io/rb/googleauth.svg)](http://badge.fury.io/rb/googleauth)
-[![Coverage Status](https://coveralls.io/repos/google/google-auth-library-ruby/badge.svg)](https://coveralls.io/r/google/google-auth-library-ruby)
 
 ## Description
 
@@ -179,15 +178,13 @@ access and refresh tokens. Two storage implementations are included:
 *   Google::Auth::Stores::RedisTokenStore
 
 Custom storage implementations can also be used. See
-[token_store.rb](lib/googleauth/token_store.rb) for additional details.
+[token_store.rb](https://googleapis.dev/ruby/googleauth/latest/Google/Auth/TokenStore.html) for additional details.
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 2.3+.
+This library requires Ruby 2.4 or later.
 
-However, Ruby 2.4 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After March 31, 2019, Google will provide
-official support only for Ruby versions that are considered current and
+In general, this library supports Ruby versions that are considered current and
 supported by Ruby Core (that is, Ruby versions that are either in normal
 maintenance or in security maintenance).
 See https://www.ruby-lang.org/en/downloads/branches/ for further details.
@@ -209,7 +206,6 @@ hesitate to
 [ask questions](http://stackoverflow.com/questions/tagged/google-auth-library-ruby)
 about the client or APIs on [StackOverflow](http://stackoverflow.com).
 
-[google-apis-ruby-client]: (https://github.com/google/google-api-ruby-client)
-[application default credentials]: (https://developers.google.com/accounts/docs/application-default-credentials)
-[contributing]: https://github.com/google/google-auth-library-ruby/tree/master/CONTRIBUTING.md
-[copying]: https://github.com/google/google-auth-library-ruby/tree/master/COPYING
+[application default credentials]: https://developers.google.com/accounts/docs/application-default-credentials
+[contributing]: https://github.com/googleapis/google-auth-library-ruby/tree/master/.github/CONTRIBUTING.md
+[copying]: https://github.com/googleapis/google-auth-library-ruby/tree/master/COPYING
diff --git a/Rakefile b/Rakefile
index 0b5c311..cf539f6 100755
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # -*- ruby -*-
+require "json"
 require "bundler/gem_tasks"
 
 task :ci do
@@ -7,12 +8,12 @@ task :ci do
   sh "bundle exec rspec"
 end
 
-task :release, :tag do |_t, args|
+task :release_gem, :tag do |_t, args|
   tag = args[:tag]
   raise "You must provide a tag to release." if tag.nil?
 
   # Verify the tag format "vVERSION"
-  m = tag.match(/v(?<version>\S*)/)
+  m = tag.match /v(?<version>\S*)/
   raise "Tag #{tag} does not match the expected format." if m.nil?
 
   version = m[:version]
@@ -33,17 +34,24 @@ task :release, :tag do |_t, args|
     sh "bundle exec rake build"
   end
 
-  path_to_be_pushed = "pkg/#{version}.gem"
+  path_to_be_pushed = "pkg/googleauth-#{version}.gem"
+  gem_was_published = nil
   if File.file? path_to_be_pushed
     begin
-      ::Gems.push File.new(path_to_be_pushed)
+      response = ::Gems.push File.new(path_to_be_pushed)
+      puts response
+      raise unless response.include? "Successfully registered gem:"
+      gem_was_published = true
       puts "Successfully built and pushed googleauth for version #{version}"
     rescue StandardError => e
+      gem_was_published = false
       puts "Error while releasing googleauth version #{version}: #{e.message}"
     end
   else
     raise "Cannot build googleauth for version #{version}"
   end
+
+  Rake::Task["kokoro:publish_docs"].invoke if gem_was_published
 end
 
 namespace :kokoro do
@@ -63,6 +71,14 @@ namespace :kokoro do
     Rake::Task["ci"].invoke
   end
 
+  task :post do
+    require_relative "rakelib/link_checker.rb"
+
+    link_checker = LinkChecker.new
+    link_checker.run
+    exit link_checker.exit_status
+  end
+
   task :nightly do
     Rake::Task["ci"].invoke
   end
@@ -75,7 +91,13 @@ namespace :kokoro do
                 .first.split("(").last.split(")").first || "0.1.0"
     end
     Rake::Task["kokoro:load_env_vars"].invoke
-    Rake::Task["release"].invoke "v/#{version}"
+    Rake::Task["release_gem"].invoke "v#{version}"
+  end
+
+  task :publish_docs do
+    require_relative "rakelib/devsite_builder.rb"
+
+    DevsiteBuilder.new(__dir__).publish
   end
 end
 
diff --git a/googleauth.gemspec b/googleauth.gemspec
index 4d4d560..2370bd2 100755
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -1,7 +1,7 @@
 # -*- ruby -*-
 # encoding: utf-8
 
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "googleauth/version"
 
 Gem::Specification.new do |gem|
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.version       = Google::Auth::VERSION
   gem.authors       = ["Tim Emiola"]
   gem.email         = "temiola@google.com"
-  gem.homepage      = "https://github.com/google/google-auth-library-ruby"
+  gem.homepage      = "https://github.com/googleapis/google-auth-library-ruby"
   gem.summary       = "Google Auth Library for Ruby"
   gem.license       = "Apache-2.0"
   gem.description   = <<-DESCRIPTION
@@ -25,11 +25,13 @@ Gem::Specification.new do |gem|
   end
   gem.require_paths = ["lib"]
   gem.platform      = Gem::Platform::RUBY
+  gem.required_ruby_version = ">= 2.4.0"
 
-  gem.add_dependency "faraday", "~> 0.12"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
-  gem.add_dependency "signet", "~> 0.7"
+  gem.add_dependency "signet", "~> 0.14"
+  gem.add_development_dependency "yard", "~> 0.9"
 end
diff --git a/lib/googleauth/application_default.rb b/lib/googleauth/application_default.rb
index 774169c..b86142f 100644
--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -34,18 +34,20 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NOT_FOUND_ERROR = <<-ERROR_MESSAGE.freeze
-Could not load the default credentials. Browse to
-https://developers.google.com/accounts/docs/application-default-credentials
-for more information
-ERROR_MESSAGE
+    NOT_FOUND_ERROR = <<~ERROR_MESSAGE.freeze
+      Could not load the default credentials. Browse to
+      https://developers.google.com/accounts/docs/application-default-credentials
+      for more information
+    ERROR_MESSAGE
+
+    module_function
 
     # Obtains the default credentials implementation to use in this
     # environment.
     #
     # Use this to obtain the Application Default Credentials for accessing
     # Google APIs.  Application Default Credentials are described in detail
-    # at http://goo.gl/IUuyuX.
+    # at https://cloud.google.com/docs/authentication/production.
     #
     # If supplied, scope is used to create the credentials instance, when it can
     # be applied.  E.g, on google compute engine and for user credentials the
@@ -75,7 +77,5 @@ ERROR_MESSAGE
       end
       GCECredentials.new
     end
-
-    module_function :get_application_default
   end
 end
diff --git a/lib/googleauth/compute_engine.rb b/lib/googleauth/compute_engine.rb
index c067835..41c38f3 100644
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -35,46 +35,42 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NO_METADATA_SERVER_ERROR = <<-ERROR.freeze
-Error code 404 trying to get security access token
-from Compute Engine metadata for the default service account. This
-may be because the virtual machine instance does not have permission
-scopes specified.
-ERROR
-    UNEXPECTED_ERROR_SUFFIX = <<-ERROR.freeze
-trying to get security access token from Compute Engine metadata for
-the default service account
-ERROR
+    NO_METADATA_SERVER_ERROR = <<~ERROR.freeze
+      Error code 404 trying to get security access token
+      from Compute Engine metadata for the default service account. This
+      may be because the virtual machine instance does not have permission
+      scopes specified.
+    ERROR
+    UNEXPECTED_ERROR_SUFFIX = <<~ERROR.freeze
+      trying to get security access token from Compute Engine metadata for
+      the default service account
+    ERROR
 
     # Extends Signet::OAuth2::Client so that the auth token is obtained from
     # the GCE metadata server.
     class GCECredentials < Signet::OAuth2::Client
       # The IP Address is used in the URIs to speed up failures on non-GCE
       # systems.
-      COMPUTE_AUTH_TOKEN_URI = "http://169.254.169.254/computeMetadata/v1/"\
-      "instance/service-accounts/default/token".freeze
+      COMPUTE_AUTH_TOKEN_URI =
+        "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token".freeze
+      COMPUTE_ID_TOKEN_URI =
+        "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity".freeze
       COMPUTE_CHECK_URI = "http://169.254.169.254".freeze
 
       class << self
         extend Memoist
 
         # Detect if this appear to be a GCE instance, by checking if metadata
-        # is available
+        # is available.
         def on_gce? options = {}
+          # TODO: This should use google-cloud-env instead.
           c = options[:connection] || Faraday.default_connection
-          resp = c.get COMPUTE_CHECK_URI do |req|
-            # Comment from: oauth2client/client.py
-            #
-            # Note: the explicit `timeout` below is a workaround. The underlying
-            # issue is that resolving an unknown host on some networks will take
-            # 20-30 seconds; making this timeout short fixes the issue, but
-            # could lead to false negatives in the event that we are on GCE, but
-            # the metadata resolution was particularly slow. The latter case is
-            # "unlikely".
-            req.options.timeout = 0.1
+          headers = { "Metadata-Flavor" => "Google" }
+          resp = c.get COMPUTE_CHECK_URI, nil, headers do |req|
+            req.options.timeout = 1.0
+            req.options.open_timeout = 0.1
           end
           return false unless resp.status == 200
-          return false unless resp.headers.key? "Metadata-Flavor"
           resp.headers["Metadata-Flavor"] == "Google"
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
           false
@@ -88,12 +84,18 @@ ERROR
       def fetch_access_token options = {}
         c = options[:connection] || Faraday.default_connection
         retry_with_error do
+          uri = target_audience ? COMPUTE_ID_TOKEN_URI : COMPUTE_AUTH_TOKEN_URI
+          query = target_audience ? { "audience" => target_audience, "format" => "full" } : nil
           headers = { "Metadata-Flavor" => "Google" }
-          resp = c.get COMPUTE_AUTH_TOKEN_URI, nil, headers
+          resp = c.get uri, query, headers
           case resp.status
           when 200
-            Signet::OAuth2.parse_credentials(resp.body,
-                                             resp.headers["content-type"])
+            content_type = resp.headers["content-type"]
+            if content_type == "text/html"
+              { (target_audience ? "id_token" : "access_token") => resp.body }
+            else
+              Signet::OAuth2.parse_credentials resp.body, content_type
+            end
           when 404
             raise Signet::AuthorizationError, NO_METADATA_SERVER_ERROR
           else
diff --git a/lib/googleauth/credentials.rb b/lib/googleauth/credentials.rb
index 4db5954..531f0f5 100644
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -47,6 +47,8 @@ module Google
       # The default target audience ID to be used when none is provided during initialization.
       AUDIENCE = "https://oauth2.googleapis.com/token".freeze
 
+      @audience = @scope = @target_audience = @env_vars = @paths = nil
+
       ##
       # The default token credential URI to be used when none is provided during initialization.
       # The URI is the authorization server's HTTP endpoint capable of issuing tokens and
@@ -97,20 +99,25 @@ module Google
       # A scope is an access range defined by the authorization server.
       # The scope can be a single value or a list of values.
       #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
       # @return [String, Array<String>]
       #
       def self.scope
         return @scope unless @scope.nil?
 
-        tmp_scope = []
-        # Pull in values is the SCOPE constant exists.
-        tmp_scope << const_get(:SCOPE) if const_defined? :SCOPE
-        tmp_scope.flatten.uniq
+        Array(const_get(:SCOPE)).flatten.uniq if const_defined? :SCOPE
       end
 
       ##
       # Sets the default scope to be used when none is provided during initialization.
       #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
       # @param [String, Array<String>] new_scope
       # @return [String, Array<String>]
       #
@@ -119,6 +126,34 @@ module Google
         @scope = new_scope
       end
 
+      ##
+      # The default final target audience for ID tokens, to be used when none
+      # is provided during initialization.
+      #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
+      # @return [String]
+      #
+      def self.target_audience
+        @target_audience
+      end
+
+      ##
+      # Sets the default final target audience for ID tokens, to be used when none
+      # is provided during initialization.
+      #
+      # Either {#scope} or {#target_audience}, but not both, should be non-nil.
+      # If {#scope} is set, this credential will produce access tokens.
+      # If {#target_audience} is set, this credential will produce ID tokens.
+      #
+      # @param [String] new_target_audience
+      #
+      def self.target_audience= new_target_audience
+        @target_audience = new_target_audience
+      end
+
       ##
       # The environment variables to search for credentials. Values can either be a file path to the
       # credentials file, or the JSON contents of the credentials file.
@@ -185,6 +220,13 @@ module Google
       #
       attr_reader :project_id
 
+      ##
+      # Identifier for a separate project used for billing/quota, if any.
+      #
+      # @return [String,nil]
+      #
+      attr_reader :quota_project_id
+
       # @private Delegate client methods to the client object.
       extend Forwardable
 
@@ -201,6 +243,9 @@ module Google
       #   @return [String, Array<String>] The scope for this client. A scope is an access range
       #     defined by the authorization server. The scope can be a single value or a list of values.
       #
+      # @!attribute [r] target_audience
+      #   @return [String] The final target audience for ID tokens returned by this credential.
+      #
       # @!attribute [r] issuer
       #   @return [String] The issuer ID associated with this client.
       #
@@ -213,9 +258,7 @@ module Google
       #
       def_delegators :@client,
                      :token_credential_uri, :audience,
-                     :scope, :issuer, :signing_key, :updater_proc
-
-      # rubocop:disable Metrics/AbcSize
+                     :scope, :issuer, :signing_key, :updater_proc, :target_audience
 
       ##
       # Creates a new Credentials instance with the provided auth credentials, and with the default
@@ -236,29 +279,23 @@ module Google
       #   * +:default_connection+ - the default connection to use for the client
       #
       def initialize keyfile, options = {}
-        scope = options[:scope]
         verify_keyfile_provided! keyfile
         @project_id = options["project_id"] || options["project"]
+        @quota_project_id = options["quota_project_id"]
         if keyfile.is_a? Signet::OAuth2::Client
-          @client = keyfile
-          @project_id ||= keyfile.project_id if keyfile.respond_to? :project_id
+          update_from_signet keyfile
         elsif keyfile.is_a? Hash
-          hash = stringify_hash_keys keyfile
-          hash["scope"] ||= scope
-          @client = init_client hash, options
-          @project_id ||= (hash["project_id"] || hash["project"])
+          update_from_hash keyfile, options
         else
-          verify_keyfile_exists! keyfile
-          json = JSON.parse ::File.read(keyfile)
-          json["scope"] ||= scope
-          @project_id ||= (json["project_id"] || json["project"])
-          @client = init_client json, options
+          update_from_filepath keyfile, options
         end
         CredentialsLoader.warn_if_cloud_sdk_credentials @client.client_id
         @project_id ||= CredentialsLoader.load_gcloud_project_id
         @client.fetch_access_token!
+        @env_vars = nil
+        @paths = nil
+        @scope = nil
       end
-      # rubocop:enable Metrics/AbcSize
 
       ##
       # Creates a new Credentials instance with auth credentials acquired by searching the
@@ -320,7 +357,8 @@ module Google
       # @private Lookup Credentials using Google::Auth.get_application_default.
       def self.from_application_default options
         scope = options[:scope] || self.scope
-        client = Google::Auth.get_application_default scope
+        auth_opts = { target_audience: options[:target_audience] || target_audience }
+        client = Google::Auth.get_application_default scope, auth_opts
         new client, options
       end
 
@@ -359,14 +397,46 @@ module Google
         options["token_credential_uri"] ||= self.class.token_credential_uri
         options["audience"] ||= self.class.audience
         options["scope"] ||= self.class.scope
+        options["target_audience"] ||= self.class.target_audience
 
+        if !Array(options["scope"]).empty? && options["target_audience"]
+          raise ArgumentError, "Cannot specify both scope and target_audience"
+        end
+
+        needs_scope = options["target_audience"].nil?
         # client options for initializing signet client
         { token_credential_uri: options["token_credential_uri"],
           audience:             options["audience"],
-          scope:                Array(options["scope"]),
+          scope:                (needs_scope ? Array(options["scope"]) : nil),
+          target_audience:      options["target_audience"],
           issuer:               options["client_email"],
           signing_key:          OpenSSL::PKey::RSA.new(options["private_key"]) }
       end
+
+      def update_from_signet client
+        @project_id ||= client.project_id if client.respond_to? :project_id
+        @quota_project_id ||= client.quota_project_id if client.respond_to? :quota_project_id
+        @client = client
+      end
+
+      def update_from_hash hash, options
+        hash = stringify_hash_keys hash
+        hash["scope"] ||= options[:scope]
+        hash["target_audience"] ||= options[:target_audience]
+        @project_id ||= (hash["project_id"] || hash["project"])
+        @quota_project_id ||= hash["quota_project_id"]
+        @client = init_client hash, options
+      end
+
+      def update_from_filepath path, options
+        verify_keyfile_exists! path
+        json = JSON.parse ::File.read(path)
+        json["scope"] ||= options[:scope]
+        json["target_audience"] ||= options[:target_audience]
+        @project_id ||= (json["project_id"] || json["project"])
+        @quota_project_id ||= json["quota_project_id"]
+        @client = init_client json, options
+      end
     end
   end
 end
diff --git a/lib/googleauth/credentials_loader.rb b/lib/googleauth/credentials_loader.rb
index c2ab551..79bee2c 100644
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -64,13 +64,13 @@ module Google
       CLOUD_SDK_CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.app"\
         "s.googleusercontent.com".freeze
 
-      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated "\
-        "using end user credentials from Google Cloud SDK. We recommend that "\
-        "most server applications use service accounts instead. If your "\
-        "application continues to use end user credentials from Cloud SDK, "\
-        'you might receive a "quota exceeded" or "API not enabled" error. For'\
-        " more information about service accounts, see "\
-        "https://cloud.google.com/docs/authentication/.".freeze
+      CLOUD_SDK_CREDENTIALS_WARNING = "Your application has authenticated using end user "\
+        "credentials from Google Cloud SDK. We recommend that most server applications use "\
+        "service accounts instead. If your application continues to use end user credentials "\
+        'from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For '\
+        "more information about service accounts, see "\
+        "https://cloud.google.com/docs/authentication/. To suppress this message, set the "\
+        "GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS environment variable.".freeze
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -163,11 +163,13 @@ module Google
         raise "#{SYSTEM_DEFAULT_ERROR}: #{e}"
       end
 
+      module_function
+
       # Issues warning if cloud sdk client id is used
       def warn_if_cloud_sdk_credentials client_id
+        return if ENV["GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS"]
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
-      module_function :warn_if_cloud_sdk_credentials
 
       # Finds project_id from gcloud CLI configuration
       def load_gcloud_project_id
@@ -179,7 +181,6 @@ module Google
       rescue StandardError
         nil
       end
-      module_function :load_gcloud_project_id
 
       private
 
@@ -193,15 +194,13 @@ module Google
       end
 
       def service_account_env_vars?
-        [PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR].all? do |key|
-          ENV[key] && !ENV[key].empty?
-        end
+        ([PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR] - ENV.keys).empty? &&
+          !ENV.to_h.fetch_values(PRIVATE_KEY_VAR, CLIENT_EMAIL_VAR).join(" ").empty?
       end
 
       def authorized_user_env_vars?
-        [CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR].all? do |key|
-          ENV[key] && !ENV[key].empty?
-        end
+        ([CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR] - ENV.keys).empty? &&
+          !ENV.to_h.fetch_values(CLIENT_ID_VAR, CLIENT_SECRET_VAR, REFRESH_TOKEN_VAR).join(" ").empty?
       end
     end
   end
diff --git a/lib/googleauth/json_key_reader.rb b/lib/googleauth/json_key_reader.rb
index 4f5002f..471ee42 100644
--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -38,8 +38,12 @@ module Google
         json_key = MultiJson.load json_key_io.read
         raise "missing client_email" unless json_key.key? "client_email"
         raise "missing private_key" unless json_key.key? "private_key"
-        project_id = json_key["project_id"]
-        [json_key["private_key"], json_key["client_email"], project_id]
+        [
+          json_key["private_key"],
+          json_key["client_email"],
+          json_key["project_id"],
+          json_key["quota_project_id"]
+        ]
       end
     end
   end
diff --git a/lib/googleauth/service_account.rb b/lib/googleauth/service_account.rb
index 849b6ae..b56bdff 100644
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -45,34 +45,40 @@ module Google
     # from credentials from a json key file downloaded from the developer
     # console (via 'Generate new Json Key').
     #
-    # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
+    # cf [Application Default Credentials](https://cloud.google.com/docs/authentication/production)
     class ServiceAccountCredentials < Signet::OAuth2::Client
       TOKEN_CRED_URI = "https://www.googleapis.com/oauth2/v4/token".freeze
       extend CredentialsLoader
       extend JsonKeyReader
       attr_reader :project_id
+      attr_reader :quota_project_id
 
       # Creates a ServiceAccountCredentials.
       #
       # @param json_key_io [IO] an IO from which the JSON key can be read
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
-        json_key_io, scope = options.values_at :json_key_io, :scope
+        json_key_io, scope, target_audience = options.values_at :json_key_io, :scope, :target_audience
+        raise ArgumentError, "Cannot specify both scope and target_audience" if scope && target_audience
+
         if json_key_io
-          private_key, client_email, project_id = read_json_key json_key_io
+          private_key, client_email, project_id, quota_project_id = read_json_key json_key_io
         else
           private_key = unescape ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
+          quota_project_id = nil
         end
         project_id ||= CredentialsLoader.load_gcloud_project_id
 
         new(token_credential_uri: TOKEN_CRED_URI,
             audience:             TOKEN_CRED_URI,
             scope:                scope,
+            target_audience:      target_audience,
             issuer:               client_email,
             signing_key:          OpenSSL::PKey::RSA.new(private_key),
-            project_id:           project_id)
+            project_id:           project_id,
+            quota_project_id:     quota_project_id)
           .configure_connection(options)
       end
 
@@ -87,6 +93,7 @@ module Google
 
       def initialize options = {}
         @project_id = options[:project_id]
+        @quota_project_id = options[:quota_project_id]
         super options
       end
 
@@ -123,7 +130,7 @@ module Google
     # console (via 'Generate new Json Key').  It is not part of any OAuth2
     # flow, rather it creates a JWT and sends that as a credential.
     #
-    # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
+    # cf [Application Default Credentials](https://cloud.google.com/docs/authentication/production)
     class ServiceAccountJwtHeaderCredentials
       JWT_AUD_URI_KEY = :jwt_aud_uri
       AUTH_METADATA_KEY = Signet::OAuth2::AUTH_METADATA_KEY
@@ -133,6 +140,7 @@ module Google
       extend CredentialsLoader
       extend JsonKeyReader
       attr_reader :project_id
+      attr_reader :quota_project_id
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -151,12 +159,13 @@ module Google
       def initialize options = {}
         json_key_io = options[:json_key_io]
         if json_key_io
-          @private_key, @issuer, @project_id =
+          @private_key, @issuer, @project_id, @quota_project_id =
             self.class.read_json_key json_key_io
         else
           @private_key = ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           @issuer = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
           @project_id = ENV[CredentialsLoader::PROJECT_ID_VAR]
+          @quota_project_id = nil
         end
         @project_id ||= CredentialsLoader.load_gcloud_project_id
         @signing_key = OpenSSL::PKey::RSA.new @private_key
diff --git a/lib/googleauth/signet.rb b/lib/googleauth/signet.rb
index 197367f..d2b33ff 100644
--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -48,8 +48,9 @@ module Signet
       def apply! a_hash, opts = {}
         # fetch the access token there is currently not one, or if the client
         # has expired
-        fetch_access_token! opts if access_token.nil? || expires_within?(60)
-        a_hash[AUTH_METADATA_KEY] = "Bearer #{access_token}"
+        token_type = target_audience ? :id_token : :access_token
+        fetch_access_token! opts if send(token_type).nil? || expires_within?(60)
+        a_hash[AUTH_METADATA_KEY] = "Bearer #{send token_type}"
       end
 
       # Returns a clone of a_hash updated with the authentication token
@@ -66,7 +67,7 @@ module Signet
       end
 
       def on_refresh &block
-        @refresh_listeners ||= []
+        @refresh_listeners = [] unless defined? @refresh_listeners
         @refresh_listeners << block
       end
 
@@ -84,15 +85,16 @@ module Signet
       end
 
       def notify_refresh_listeners
-        listeners = @refresh_listeners || []
+        listeners = defined?(@refresh_listeners) ? @refresh_listeners : []
         listeners.each do |block|
           block.call self
         end
       end
 
       def build_default_connection
-        return nil unless defined?(@connection_info)
-        if @connection_info.respond_to? :call
+        if !defined?(@connection_info)
+          nil
+        elsif @connection_info.respond_to? :call
           @connection_info.call
         else
           @connection_info
diff --git a/lib/googleauth/user_authorizer.rb b/lib/googleauth/user_authorizer.rb
index 0526dad..90c3761 100644
--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -129,8 +129,8 @@ module Google
         data = MultiJson.load saved_token
 
         if data.fetch("client_id", @client_id.id) != @client_id.id
-          raise sprintf(MISMATCHED_CLIENT_ID_ERROR,
-                        data["client_id"], @client_id.id)
+          raise format(MISMATCHED_CLIENT_ID_ERROR,
+                       data["client_id"], @client_id.id)
         end
 
         credentials = UserRefreshCredentials.new(
@@ -271,10 +271,15 @@ module Google
       # @return [String]
       #  Redirect URI
       def redirect_uri_for base_url
-        return @callback_uri unless URI(@callback_uri).scheme.nil?
+        return @callback_uri if uri_is_postmessage?(@callback_uri) || !URI(@callback_uri).scheme.nil?
         raise format(MISSING_ABSOLUTE_URL_ERROR, @callback_uri) if base_url.nil? || URI(base_url).scheme.nil?
         URI.join(base_url, @callback_uri).to_s
       end
+
+      # Check if URI is Google's postmessage flow (not a valid redirect_uri by spec, but allowed)
+      def uri_is_postmessage? uri
+        uri.to_s.casecmp("postmessage").zero?
+      end
     end
   end
 end
diff --git a/lib/googleauth/user_refresh.rb b/lib/googleauth/user_refresh.rb
index f3c4fda..53bb1d2 100644
--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -44,7 +44,7 @@ module Google
     # 'gcloud auth login' saves a file with these contents in well known
     # location
     #
-    # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
+    # cf [Application Default Credentials](https://cloud.google.com/docs/authentication/production)
     class UserRefreshCredentials < Signet::OAuth2::Client
       TOKEN_CRED_URI = "https://oauth2.googleapis.com/token".freeze
       AUTHORIZATION_URI = "https://accounts.google.com/o/oauth2/auth".freeze
diff --git a/lib/googleauth/version.rb b/lib/googleauth/version.rb
index 89885e1..93a1da6 100644
--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.9.0".freeze
+    VERSION = "0.11.0".freeze
   end
 end
diff --git a/lib/googleauth/web_user_authorizer.rb b/lib/googleauth/web_user_authorizer.rb
index 1cb9fb5..545506a 100644
--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -171,7 +171,7 @@ module Google
         options[:state] = MultiJson.dump(state.merge(
                                            SESSION_ID_KEY  => request.session[XSRF_KEY],
                                            CURRENT_URI_KEY => redirect_to
-        ))
+                                         ))
         options[:base_url] = request.url
         super options
       end
diff --git a/rakelib/devsite_builder.rb b/rakelib/devsite_builder.rb
new file mode 100644
index 0000000..06ebb7a
--- /dev/null
+++ b/rakelib/devsite_builder.rb
@@ -0,0 +1,45 @@
+require "pathname"
+
+require_relative "repo_metadata.rb"
+
+class DevsiteBuilder
+  def initialize master_dir = "."
+    @master_dir = Pathname.new master_dir
+    @output_dir = "doc"
+    @metadata = RepoMetadata.from_source "#{master_dir}/.repo-metadata.json"
+  end
+
+  def build
+    FileUtils.remove_dir @output_dir if Dir.exist? @output_dir
+    markup = "--markup markdown"
+
+    Dir.chdir @master_dir do
+      cmds = ["-o #{@output_dir}", markup]
+      cmd "yard --verbose #{cmds.join ' '}"
+    end
+    @metadata.build @master_dir + @output_dir
+  end
+
+  def upload
+    Dir.chdir @output_dir do
+      opts = [
+        "--credentials=#{ENV['KOKORO_KEYSTORE_DIR']}/73713_docuploader_service_account",
+        "--staging-bucket=#{ENV.fetch 'STAGING_BUCKET', 'docs-staging'}",
+        "--metadata-file=./docs.metadata"
+      ]
+      cmd "python3 -m docuploader upload . #{opts.join ' '}"
+    end
+  end
+
+  def publish
+    build
+    upload
+  end
+
+  def cmd line
+    puts line
+    output = `#{line}`
+    puts output
+    output
+  end
+end
diff --git a/rakelib/link_checker.rb b/rakelib/link_checker.rb
new file mode 100644
index 0000000..ec7bb95
--- /dev/null
+++ b/rakelib/link_checker.rb
@@ -0,0 +1,64 @@
+require "open3"
+
+class LinkChecker
+  def initialize
+    @failed = false
+  end
+
+  def run
+    job_info
+    git_commit = ENV.fetch "KOKORO_GITHUB_COMMIT", "master"
+
+    markdown_files = Dir.glob "**/*.md"
+    broken_markdown_links = check_links markdown_files,
+                                        "https://github.com/googleapis/google-auth-library-ruby/tree/#{git_commit}",
+                                        " --skip '^(?!(\\Wruby.*google|.*google.*\\Wruby|.*cloud\\.google\\.com))'"
+
+    broken_devsite_links = check_links ["googleauth"],
+                                       "https://googleapis.dev/ruby",
+                                       "/latest/ --recurse --skip https:.*github.*"
+
+    puts_broken_links broken_markdown_links
+    puts_broken_links broken_devsite_links
+  end
+
+  def check_links location_list, base, tail
+    broken_links = Hash.new { |h, k| h[k] = [] }
+    location_list.each do |location|
+      out, err, st = Open3.capture3 "npx linkinator #{base}/#{location}#{tail}"
+      puts out
+      unless st.to_i.zero?
+        @failed = true
+        puts err
+      end
+      checked_links = out.split "\n"
+      checked_links.select! { |link| link =~ /\[\d+\]/ && !link.include?("[200]") }
+      unless checked_links.empty?
+        @failed = true
+        broken_links[location] += checked_links
+      end
+    end
+    broken_links
+  end
+
+  def puts_broken_links link_hash
+    link_hash.each do |location, links|
+      puts "#{location} contains the following broken links:"
+      links.each { |link| puts "  #{link}" }
+      puts ""
+    end
+  end
+
+  def job_info
+    line_length = "Using Ruby - #{RUBY_VERSION}".length + 8
+    puts ""
+    puts "#" * line_length
+    puts "### Using Ruby - #{RUBY_VERSION} ###"
+    puts "#" * line_length
+    puts ""
+  end
+
+  def exit_status
+    @failed ? 1 : 0
+  end
+end
diff --git a/rakelib/repo_metadata.rb b/rakelib/repo_metadata.rb
new file mode 100644
index 0000000..12a833a
--- /dev/null
+++ b/rakelib/repo_metadata.rb
@@ -0,0 +1,59 @@
+require "json"
+
+class RepoMetadata
+  attr_reader :data
+
+  def initialize data
+    @data = data
+    normalize_data!
+  end
+
+  def allowed_fields
+    [
+      "name", "version", "language", "distribution-name",
+      "product-page", "github-repository", "issue-tracker"
+    ]
+  end
+
+  def build output_directory
+    fields = @data.to_a.map { |kv| "--#{kv[0]} #{kv[1]}" }
+    Dir.chdir output_directory do
+      cmd "python3 -m docuploader create-metadata #{fields.join ' '}"
+    end
+  end
+
+  def normalize_data!
+    require_relative "../lib/googleauth/version.rb"
+
+    @data.delete_if { |k, _| !allowed_fields.include?(k) }
+    @data["version"] = "v#{Google::Auth::VERSION}"
+  end
+
+  def [] key
+    data[key]
+  end
+
+  def []= key, value
+    @data[key] = value
+  end
+
+  def cmd line
+    puts line
+    output = `#{line}`
+    puts output
+    output
+  end
+
+  def self.from_source source
+    if source.is_a? RepoMetadata
+      data = source.data
+    elsif source.is_a? Hash
+      data = source
+    elsif File.file? source
+      data = JSON.parse File.read(source)
+    else
+      raise "Source must be a path, hash, or RepoMetadata instance"
+    end
+    RepoMetadata.new data
+  end
+end
diff --git a/spec/googleauth/apply_auth_examples.rb b/spec/googleauth/apply_auth_examples.rb
index ee9ac72..cdbdbbc 100644
--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -45,26 +45,37 @@ shared_examples "apply/apply! are OK" do
   # auth client
   describe "#fetch_access_token" do
     let(:token) { "1/abcdef1234567890" }
-    let :stub do
+    let :access_stub do
       make_auth_stubs access_token: token
     end
+    let :id_stub do
+      make_auth_stubs id_token: token
+    end
 
     it "should set access_token to the fetched value" do
-      stub
+      access_stub
       @client.fetch_access_token!
       expect(@client.access_token).to eq(token)
-      expect(stub).to have_been_requested
+      expect(access_stub).to have_been_requested
+    end
+
+    it "should set id_token to the fetched value" do
+      skip unless @id_client
+      id_stub
+      @id_client.fetch_access_token!
+      expect(@id_client.id_token).to eq(token)
+      expect(id_stub).to have_been_requested
     end
 
     it "should notify refresh listeners after updating" do
-      stub
+      access_stub
       expect do |b|
         @client.on_refresh(&b)
         @client.fetch_access_token!
       end.to yield_with_args(have_attributes(
                                access_token: "1/abcdef1234567890"
                              ))
-      expect(stub).to have_been_requested
+      expect(access_stub).to have_been_requested
     end
   end
 
diff --git a/spec/googleauth/compute_engine_spec.rb b/spec/googleauth/compute_engine_spec.rb
index 6429405..58645f5 100644
--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -37,23 +37,32 @@ require "googleauth/compute_engine"
 require "spec_helper"
 
 describe Google::Auth::GCECredentials do
-  MD_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token".freeze
+  MD_ACCESS_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token".freeze
+  MD_ID_URI = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://pubsub.googleapis.com/&format=full".freeze
   GCECredentials = Google::Auth::GCECredentials
 
   before :example do
     @client = GCECredentials.new
+    @id_client = GCECredentials.new target_audience: "https://pubsub.googleapis.com/"
   end
 
-  def make_auth_stubs opts = {}
-    access_token = opts[:access_token] || ""
-    body = MultiJson.dump("access_token" => access_token,
-                          "token_type"   => "Bearer",
-                          "expires_in"   => 3600)
-    stub_request(:get, MD_URI)
-      .with(headers: { "Metadata-Flavor" => "Google" })
-      .to_return(body:    body,
-                 status:  200,
-                 headers: { "Content-Type" => "application/json" })
+  def make_auth_stubs opts
+    if opts[:access_token]
+      body = MultiJson.dump("access_token" => opts[:access_token],
+                            "token_type"   => "Bearer",
+                            "expires_in"   => 3600)
+      stub_request(:get, MD_ACCESS_URI)
+        .with(headers: { "Metadata-Flavor" => "Google" })
+        .to_return(body:    body,
+                   status:  200,
+                   headers: { "Content-Type" => "application/json" })
+    elsif opts[:id_token]
+      stub_request(:get, MD_ID_URI)
+        .with(headers: { "Metadata-Flavor" => "Google" })
+        .to_return(body:    opts[:id_token],
+                   status:  200,
+                   headers: { "Content-Type" => "text/html" })
+    end
   end
 
   it_behaves_like "apply/apply! are OK"
@@ -61,7 +70,7 @@ describe Google::Auth::GCECredentials do
   context "metadata is unavailable" do
     describe "#fetch_access_token" do
       it "should fail if the metadata request returns a 404" do
-        stub = stub_request(:get, MD_URI)
+        stub = stub_request(:get, MD_ACCESS_URI)
                .to_return(status:  404,
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @client.fetch_access_token! }
@@ -70,7 +79,7 @@ describe Google::Auth::GCECredentials do
       end
 
       it "should fail if the metadata request returns an unexpected code" do
-        stub = stub_request(:get, MD_URI)
+        stub = stub_request(:get, MD_ACCESS_URI)
                .to_return(status:  503,
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @client.fetch_access_token! }
@@ -97,6 +106,7 @@ describe Google::Auth::GCECredentials do
   describe "#on_gce?" do
     it "should be true when Metadata-Flavor is Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(true)
@@ -105,6 +115,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false when Metadata-Flavor is not Google" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
@@ -113,6 +124,7 @@ describe Google::Auth::GCECredentials do
 
     it "should be false if the response is not 200" do
       stub = stub_request(:get, "http://169.254.169.254")
+             .with(headers: { "Metadata-Flavor" => "Google" })
              .to_return(status:  404,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
diff --git a/spec/googleauth/credentials_spec.rb b/spec/googleauth/credentials_spec.rb
index 3cb2183..de29854 100644
--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -36,12 +36,13 @@ require "googleauth"
 describe Google::Auth::Credentials, :private do
   let :default_keyfile_hash do
     {
-      "private_key_id" => "testabc1234567890xyz",
-      "private_key"    => "-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAOyi0Hy1l4Ym2m2o71Q0TF4O9E81isZEsX0bb+Bqz1SXEaSxLiXM\nUZE8wu0eEXivXuZg6QVCW/5l+f2+9UPrdNUCAwEAAQJAJkqubA/Chj3RSL92guy3\nktzeodarLyw8gF8pOmpuRGSiEo/OLTeRUMKKD1/kX4f9sxf3qDhB4e7dulXR1co/\nIQIhAPx8kMW4XTTL6lJYd2K5GrH8uBMp8qL5ya3/XHrBgw3dAiEA7+3Iw3ULTn2I\n1J34WlJ2D5fbzMzB4FAHUNEV7Ys3f1kCIQDtUahCMChrl7+H5t9QS+xrn77lRGhs\nB50pjvy95WXpgQIhAI2joW6JzTfz8fAapb+kiJ/h9Vcs1ZN3iyoRlNFb61JZAiA8\nNy5NyNrMVwtB/lfJf1dAK/p/Bwd8LZLtgM6PapRfgw==\n-----END RSA PRIVATE KEY-----\n",
-      "client_email"   => "credz-testabc1234567890xyz@developer.gserviceaccount.com",
-      "client_id"      => "credz-testabc1234567890xyz.apps.googleusercontent.com",
-      "type"           => "service_account",
-      "project_id"     => "a_project_id"
+      "private_key_id"   => "testabc1234567890xyz",
+      "private_key"      => "-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAOyi0Hy1l4Ym2m2o71Q0TF4O9E81isZEsX0bb+Bqz1SXEaSxLiXM\nUZE8wu0eEXivXuZg6QVCW/5l+f2+9UPrdNUCAwEAAQJAJkqubA/Chj3RSL92guy3\nktzeodarLyw8gF8pOmpuRGSiEo/OLTeRUMKKD1/kX4f9sxf3qDhB4e7dulXR1co/\nIQIhAPx8kMW4XTTL6lJYd2K5GrH8uBMp8qL5ya3/XHrBgw3dAiEA7+3Iw3ULTn2I\n1J34WlJ2D5fbzMzB4FAHUNEV7Ys3f1kCIQDtUahCMChrl7+H5t9QS+xrn77lRGhs\nB50pjvy95WXpgQIhAI2joW6JzTfz8fAapb+kiJ/h9Vcs1ZN3iyoRlNFb61JZAiA8\nNy5NyNrMVwtB/lfJf1dAK/p/Bwd8LZLtgM6PapRfgw==\n-----END RSA PRIVATE KEY-----\n",
+      "client_email"     => "credz-testabc1234567890xyz@developer.gserviceaccount.com",
+      "client_id"        => "credz-testabc1234567890xyz.apps.googleusercontent.com",
+      "type"             => "service_account",
+      "project_id"       => "a_project_id",
+      "quota_project_id" => "b_project_id"
     }
   end
 
@@ -118,6 +119,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials1)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use PATH_ENV_VARS to get keyfile path" do
@@ -128,6 +130,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -152,6 +155,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials2)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use JSON_ENV_VARS to get keyfile contents" do
@@ -164,6 +168,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -188,6 +193,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials3)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use DEFAULT_PATHS to get keyfile path" do
@@ -198,6 +204,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -222,6 +229,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials4)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses that find no matches default to Google::Auth.get_application_default" do
@@ -232,6 +240,7 @@ describe Google::Auth::Credentials, :private do
         DEFAULT_PATHS = ["~/default/path/to/file.txt"].freeze
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -262,6 +271,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials5)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
   end
 
@@ -301,6 +311,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials11)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use PATH_ENV_VARS to get keyfile path" do
@@ -310,6 +321,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("PATH_ENV_TEST") { "/unknown/path/to/file.txt" }
@@ -334,6 +346,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials12)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use JSON_ENV_VARS to get keyfile contents" do
@@ -345,6 +358,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::File).to receive(:file?).with(test_json_env_val) { false }
@@ -369,6 +383,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials13)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses can use DEFAULT_PATHS to get keyfile path" do
@@ -378,6 +393,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -402,6 +418,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials14)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
 
     it "subclasses that find no matches default to Google::Auth.get_application_default" do
@@ -411,6 +428,7 @@ describe Google::Auth::Credentials, :private do
         self.paths = ["~/default/path/to/file.txt"]
       end
 
+      allow(::ENV).to receive(:[]).with("GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS") { "true" }
       allow(::ENV).to receive(:[]).with("PATH_ENV_DUMMY") { "/fake/path/to/file.txt" }
       allow(::File).to receive(:file?).with("/fake/path/to/file.txt") { false }
       allow(::ENV).to receive(:[]).with("JSON_ENV_DUMMY") { nil }
@@ -441,6 +459,7 @@ describe Google::Auth::Credentials, :private do
       expect(creds).to be_a_kind_of(TestCredentials15)
       expect(creds.client).to eq(mocked_signet)
       expect(creds.project_id).to eq(default_keyfile_hash["project_id"])
+      expect(creds.quota_project_id).to eq(default_keyfile_hash["quota_project_id"])
     end
   end
 
diff --git a/spec/googleauth/service_account_spec.rb b/spec/googleauth/service_account_spec.rb
index 3e138dc..e7186c6 100644
--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -112,12 +112,13 @@ describe Google::Auth::ServiceAccountCredentials do
   let(:client_email) { "app@developer.gserviceaccount.com" }
   let :cred_json do
     {
-      private_key_id: "a_private_key_id",
-      private_key:    @key.to_pem,
-      client_email:   client_email,
-      client_id:      "app.apps.googleusercontent.com",
-      type:           "service_account",
-      project_id:     "a_project_id"
+      private_key_id:   "a_private_key_id",
+      private_key:      @key.to_pem,
+      client_email:     client_email,
+      client_id:        "app.apps.googleusercontent.com",
+      type:             "service_account",
+      project_id:       "a_project_id",
+      quota_project_id: "b_project_id"
     }
   end
 
@@ -127,24 +128,28 @@ describe Google::Auth::ServiceAccountCredentials do
       json_key_io: StringIO.new(cred_json_text),
       scope:       "https://www.googleapis.com/auth/userinfo.profile"
     )
+    @id_client = ServiceAccountCredentials.make_creds(
+      json_key_io:     StringIO.new(cred_json_text),
+      target_audience: "https://pubsub.googleapis.com/"
+    )
   end
 
-  def make_auth_stubs opts = {}
-    access_token = opts[:access_token] || ""
-    body = MultiJson.dump("access_token" => access_token,
-                          "token_type"   => "Bearer",
-                          "expires_in"   => 3600)
+  def make_auth_stubs opts
+    body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
+    body_fields["access_token"] = opts[:access_token] if opts[:access_token]
+    body_fields["id_token"] = opts[:id_token] if opts[:id_token]
+    body = MultiJson.dump body_fields
     blk = proc do |request|
       params = Addressable::URI.form_unencode request.body
-      _claim, _header = JWT.decode(params.assoc("assertion").last,
-                                   @key.public_key, true,
-                                   algorithm: "RS256")
+      claim, _header = JWT.decode(params.assoc("assertion").last,
+                                  @key.public_key, true,
+                                  algorithm: "RS256")
+      !opts[:id_token] || claim["target_audience"] == "https://pubsub.googleapis.com/"
     end
     stub_request(:post, "https://www.googleapis.com/oauth2/v4/token")
       .with(body: hash_including(
         "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer"
-      ),
-            &blk)
+      ), &blk)
       .to_return(body:    body,
                  status:  200,
                  headers: { "Content-Type" => "application/json" })
@@ -285,6 +290,7 @@ describe Google::Auth::ServiceAccountCredentials do
         ENV["APPDATA"] = dir
         credentials = @clz.from_well_known_path @scope
         expect(credentials.project_id).to eq(cred_json[:project_id])
+        expect(credentials.quota_project_id).to eq(cred_json[:quota_project_id])
       end
     end
 
@@ -476,6 +482,7 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
         ENV["APPDATA"] = dir
         credentials = clz.from_well_known_path @scope
         expect(credentials.project_id).to eq(cred_json[:project_id])
+        expect(credentials.quota_project_id).to be_nil
       end
     end
   end
diff --git a/spec/googleauth/signet_spec.rb b/spec/googleauth/signet_spec.rb
index 46f05f6..b289f51 100644
--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -47,18 +47,26 @@ describe Signet::OAuth2::Client do
       audience:             "https://oauth2.googleapis.com/token",
       signing_key:          @key
     )
+    @id_client = Signet::OAuth2::Client.new(
+      token_credential_uri: "https://oauth2.googleapis.com/token",
+      target_audience:      "https://pubsub.googleapis.com/",
+      issuer:               "app@example.com",
+      audience:             "https://oauth2.googleapis.com/token",
+      signing_key:          @key
+    )
   end
 
   def make_auth_stubs opts
-    access_token = opts[:access_token] || ""
-    body = MultiJson.dump("access_token" => access_token,
-                          "token_type"   => "Bearer",
-                          "expires_in"   => 3600)
+    body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
+    body_fields["access_token"] = opts[:access_token] if opts[:access_token]
+    body_fields["id_token"] = opts[:id_token] if opts[:id_token]
+    body = MultiJson.dump body_fields
     blk = proc do |request|
       params = Addressable::URI.form_unencode request.body
-      _claim, _header = JWT.decode(params.assoc("assertion").last,
-                                   @key.public_key, true,
-                                   algorithm: "RS256")
+      claim, _header = JWT.decode(params.assoc("assertion").last,
+                                  @key.public_key, true,
+                                  algorithm: "RS256")
+      !opts[:id_token] || claim["target_audience"] == "https://pubsub.googleapis.com/"
     end
     with_params = { body: hash_including(
       "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer"
diff --git a/spec/googleauth/user_authorizer_spec.rb b/spec/googleauth/user_authorizer_spec.rb
index 5a36304..50f3f2f 100644
--- a/spec/googleauth/user_authorizer_spec.rb
+++ b/spec/googleauth/user_authorizer_spec.rb
@@ -80,7 +80,7 @@ describe Google::Auth::UserAuthorizer do
       expect(URI(uri).query).to_not match(/client_secret/)
     end
 
-    it "should include the callback uri" do
+    it "should include the redirect_uri" do
       expect(URI(uri).query).to match(
         %r{redirect_uri=https://www.example.com/oauth/callback}
       )
@@ -91,6 +91,25 @@ describe Google::Auth::UserAuthorizer do
     end
   end
 
+  context "when generating authorization URLs and callback_uri is 'postmessage'" do
+    let(:callback_uri) { "postmessage" }
+    let :authorizer do
+      Google::Auth::UserAuthorizer.new(client_id,
+                                       scope,
+                                       token_store,
+                                       callback_uri)
+    end
+    let :uri do
+      authorizer.get_authorization_url login_hint: "user1", state: "mystate"
+    end
+
+    it "should include the redirect_uri 'postmessage'" do
+      expect(URI(uri).query).to match(
+        %r{redirect_uri=postmessage}
+      )
+    end
+  end
+
   context "when generating authorization URLs with user ID & state" do
     let :uri do
       authorizer.get_authorization_url login_hint: "user1", state: "mystate"
@@ -253,6 +272,7 @@ describe Google::Auth::UserAuthorizer do
         user_id: "user1", code: "code"
       )
       expect(credentials.access_token).to eq "1/abc123"
+      expect(credentials.redirect_uri.to_s).to eq "https://www.example.com/oauth/callback"
     end
 
     it "should not store credentials when get only requested" do
diff --git a/spec/googleauth/user_refresh_spec.rb b/spec/googleauth/user_refresh_spec.rb
index 40531bd..f1d6b42 100644
--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -64,7 +64,7 @@ describe Google::Auth::UserRefreshCredentials do
     )
   end
 
-  def make_auth_stubs opts = {}
+  def make_auth_stubs opts
     access_token = opts[:access_token] || ""
     body = MultiJson.dump("access_token" => access_token,
                           "token_type"   => "Bearer",

```

</details>

This pull request was generated using releasetool.