### PR TITLE
fix: target_audience must also be null to use ServiceAccountJwtHeader…

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -104,7 +104,7 @@ module Google
       # authenticate instead.
       def apply! a_hash, opts = {}
         # Use the base implementation if scopes are set
-        unless scope.nil?
+        unless scope.nil? && target_audience.nil?
           super
           return
         end


### PR DESCRIPTION
The ID Token client was correctly fetching `id_token`, but it was not setting this via the `apply!` method. This is because the `ServiceAccountJwtHeaderCredentials` client was being used instead. The extra conditional check for `target_audience` ensures this client is not used for ID token auth

```rb
  ## BEFORE
  id_token_creds = Google::Auth::Credentials.default \
    target_audience: client_id
  headers = {}
  id_token_creds.client.apply! headers
  # puts headers => {}

  ## AFTER
  id_token_creds = Google::Auth::Credentials.default \
    target_audience: client_id
  headers = {}
  id_token_creds.client.apply! headers
  # puts headers => {'Authorization': 'Bearer xyz'}
```