### PR TITLE
Allow scope to be passed through on GKE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Support scopes when using GCE Metadata Server authentication ([@ball-hayden][])
+
 ### 0.13.0 / 2020-06-17
 
 * Support for validating ID tokens.
@@ -143,3 +147,4 @@ Note: This release now requires Ruby 2.4 or later
 [@tbetbetbe]: https://github.com/tbetbetbe
 [@murgatroid99]: https://github.com/murgatroid99
 [@vsubramani]: https://github.com/vsubramani
+[@ball-hayden]: https://github.com/ball-hayden

--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -75,7 +75,7 @@ module Google
         GCECredentials.unmemoize_all
         raise NOT_FOUND_ERROR
       end
-      GCECredentials.new
+      GCECredentials.new scope: scope
     end
   end
 end

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -85,7 +85,8 @@ module Google
         c = options[:connection] || Faraday.default_connection
         retry_with_error do
           uri = target_audience ? COMPUTE_ID_TOKEN_URI : COMPUTE_AUTH_TOKEN_URI
-          query = target_audience ? { "audience" => target_audience, "format" => "full" } : nil
+          query = target_audience ? { "audience" => target_audience, "format" => "full" } : {}
+          query[:scopes] = Array(scope).join " " if scope
           headers = { "Metadata-Flavor" => "Google" }
           resp = c.get uri, query, headers
           case resp.status


### PR DESCRIPTION
GCECredentials doesn't currently allow scopes to be passed through.

Although not documented the metadata server does support a `scopes` parameter when requesting an access token, at least when running in "workload identity" mode on GKE.

As it's not documented, I'm unsure of the behaviour when requesting multiple scopes (should they be space separated, comma separated, or passed as a parameter array?).
I'm also unsure whether this will break in non-workload identity environments?