### PR TITLE
fix: Service account credentials properly apply ID tokens

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -104,7 +104,7 @@ module Google
       # authenticate instead.
       def apply! a_hash, opts = {}
         # Use the base implementation if scopes are set
-        unless scope.nil?
+        unless scope.nil? && target_audience.nil?
           super
           return
         end

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -90,6 +90,18 @@ shared_examples "apply/apply! are OK" do
       expect(md).to eq(want)
       expect(stub).to have_been_requested
     end
+
+    it "should update the target hash with fetched ID token" do
+      skip unless @id_client
+      token = "1/abcdef1234567890"
+      stub = make_auth_stubs id_token: token
+
+      md = { foo: "bar" }
+      @id_client.apply! md
+      want = { :foo => "bar", auth_key => "Bearer #{token}" }
+      expect(md).to eq(want)
+      expect(stub).to have_been_requested
+    end
   end
 
   describe "updater_proc" do


### PR DESCRIPTION
`ServiceAccountCredential#apply` wasn't properly applying ID tokens. Fixed.