### PR TITLE
Fix passing multiple scopes to metadata server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### Unreleased
+
+* Fix issue with passing multiple scopes in metadata server authentication
+([@danielroseman][])
+
 ### 0.13.1 / 2020-07-30
 
 * Support scopes when using GCE Metadata Server authentication ([@ball-hayden][])
@@ -150,3 +155,4 @@ Note: This release now requires Ruby 2.4 or later
 [@murgatroid99]: https://github.com/murgatroid99
 [@vsubramani]: https://github.com/vsubramani
 [@ball-hayden]: https://github.com/ball-hayden
+[@danielroseman]: https://github.com/danielroseman

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -53,7 +53,10 @@ describe Google::Auth::GCECredentials do
                             "expires_in"   => 3600)
 
       uri = MD_ACCESS_URI
-      uri += "?scopes=#{opts[:scope]}" if opts[:scope]
+      if opts[:scope]
+        query = Faraday::FlatParamsEncoder.encode(scopes: opts[:scope])
+        uri += "?#{query}"
+      end
 
       stub_request(:get, uri)
         .with(headers: { "Metadata-Flavor" => "Google" })
@@ -74,9 +77,12 @@ describe Google::Auth::GCECredentials do
   context "metadata is unavailable" do
     describe "#fetch_access_token" do
       it "should pass scopes when requesting an access token" do
-        scope = "https://www.googleapis.com/auth/drive"
-        stub = make_auth_stubs access_token: "1/abcdef1234567890", scope: scope
-        @client = GCECredentials.new(scope: [scope])
+        scopes = [
+          "https://www.googleapis.com/auth/cloud-platform",
+          "https://www.googleapis.com/auth/drive"
+        ]
+        stub = make_auth_stubs access_token: "1/abcdef1234567890", scope: scopes
+        @client = GCECredentials.new(scope: scopes)
         @client.fetch_access_token!
         expect(stub).to have_been_requested
       end


### PR DESCRIPTION
In #264, a fix was made to allow passing the scopes in the request to
the metadata server. A comment on that PR pointed to Signet's use of a
space-delimited string for muliple values, so the same was implemented
here.

However this code does not actually use Signet to make the request. In
fact the server is expecting a standard form-encoded parameter, eg
`scopes=scope1&scopes=scope2`. Passing a space results in a 500 response
from the server.

This change corrects the request to use the form-encoded format.