### PR TITLE
fix: Fix errors when requesting an access token for multiple scopes

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -86,7 +86,7 @@ module Google
         retry_with_error do
           uri = target_audience ? COMPUTE_ID_TOKEN_URI : COMPUTE_AUTH_TOKEN_URI
           query = target_audience ? { "audience" => target_audience, "format" => "full" } : {}
-          query[:scopes] = Array(scope).join " " if scope
+          query[:scopes] = Array(scope).join "," if scope
           headers = { "Metadata-Flavor" => "Google" }
           resp = c.get uri, query, headers
           case resp.status

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -53,7 +53,7 @@ describe Google::Auth::GCECredentials do
                             "expires_in"   => 3600)
 
       uri = MD_ACCESS_URI
-      uri += "?scopes=#{opts[:scope]}" if opts[:scope]
+      uri += "?scopes=#{Array(opts[:scope]).join ','}" if opts[:scope]
 
       stub_request(:get, uri)
         .with(headers: { "Metadata-Flavor" => "Google" })
@@ -74,9 +74,9 @@ describe Google::Auth::GCECredentials do
   context "metadata is unavailable" do
     describe "#fetch_access_token" do
       it "should pass scopes when requesting an access token" do
-        scope = "https://www.googleapis.com/auth/drive"
-        stub = make_auth_stubs access_token: "1/abcdef1234567890", scope: scope
-        @client = GCECredentials.new(scope: [scope])
+        scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/bigtable.data"]
+        stub = make_auth_stubs access_token: "1/abcdef1234567890", scope: scopes
+        @client = GCECredentials.new(scope: scopes)
         @client.fetch_access_token!
         expect(stub).to have_been_requested
       end


### PR DESCRIPTION
Fixes #274 

When sending the scopes query parameter to the metadata server, comma-delimits instead of space-delimits multiple scopes (correcting #264). On Cloud Run, space (i.e. plus) delimiting the scopes results in a 500 from the metadata server.