### PR TITLE
Release google-auth-library-ruby 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.14.0 / 2020-10-09
+
+* Honor GCE_METADATA_HOST environment variable
+* Fix errors in some environments when requesting an access token for multiple scopes
+
 ### 0.13.1 / 2020-07-30
 
 * Support scopes when using GCE Metadata Server authentication ([@ball-hayden][])

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = "0.13.1".freeze
+    VERSION = "0.14.0".freeze
   end
 end


### PR DESCRIPTION
* Honor GCE_METADATA_HOST environment variable
* Fix errors in some environments when requesting an access token for multiple scopes

<details><summary>Commits since previous release</summary><pre><code>commit 6f71d62a6a850aeffd7a829935dab43aae209611
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Oct 9 09:51:49 2020 -0700

    fix: Fix errors when requesting an access token for multiple scopes

commit 3cdb5a8de7dfeeded3c83f4a24a7e3bd96120b2f
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Oct 9 09:32:26 2020 -0700

    feat: Honor GCE_METADATA_HOST environment variable

commit c1e0f44486dce132a0dcab59c9af3c118f6e748d
Author: Justin Beckwith <justin.beckwith@gmail.com>
Date:   Wed Sep 16 15:26:45 2020 -0700

    chore: add CODEOWNERS (#273)
</code></pre></details>

This pull request was generated using releasetool.