### PR TITLE
[REBASE MERGE] Use self-signed JWT when given default scopes

### DIFF
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -75,7 +75,7 @@ module Google
     #     creds2 = SubCredentials.default
     #     creds2.scope  # => ["http://example.com/sub_scope"]
     #
-    class Credentials
+    class Credentials # rubocop:disable Metrics/ClassLength
       ##
       # The default token credential URI to be used when none is provided during initialization.
       TOKEN_CREDENTIAL_URI = "https://oauth2.googleapis.com/token".freeze
@@ -426,7 +426,12 @@ module Google
       # @private Lookup Credentials using Google::Auth.get_application_default.
       def self.from_application_default options
         scope = options[:scope] || self.scope
-        auth_opts = { target_audience: options[:target_audience] || target_audience }
+        auth_opts = {
+          token_credential_uri:   options[:token_credential_uri] || token_credential_uri,
+          audience:               options[:audience] || audience,
+          target_audience:        options[:target_audience] || target_audience,
+          enable_self_signed_jwt: options[:enable_self_signed_jwt] && options[:scope].nil?
+        }
         client = Google::Auth.get_application_default scope, auth_opts
         new client, options
       end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -169,6 +169,14 @@ describe Google::Auth::ServiceAccountCredentials do
     it_behaves_like "jwt header auth"
   end
 
+  context "when enable_self_signed_jwt is set" do
+    before :example do
+      @client.instance_variable_set(:@enable_self_signed_jwt, true)
+    end
+
+    it_behaves_like "jwt header auth"
+  end
+
   describe "#from_env" do
     before :example do
       @var_name = ENV_VAR


### PR DESCRIPTION
This change provides support for GAPIC clients to default to self-signed JWT credentials when using a service account when custom scopes are not provided. It uses an "opt-in" model in that the client library (or end-user) needs to enable self-signed JWT support explicitly. This is because of the requirement that self-signed JWT must be disabled if the endpoint is not the service default. The credentials classes know nothing about the endpoint and cannot make this determination themselves, so to avoid breakage, the feature is disabled by default. As the next step, the Ruby GAPIC microgenerator will be enhanced to determine whether it is safe to turn on self-signed JWT (by comparing the actual endpoint with the default endpoint), and pass that information down into the credential.

This PR includes two changes, corresponding to two commits.

1. Provide a credential argument that tells the Signet client to use to the self-signed JWT path. This commit includes:
    * Update the `Google::Auth::ServiceAccountCredentials` class to take a `:enable_self_signed_jwt` flag. When set, this indicates the caller has determined that self-signed JWT should be used if possible.
    * Update the `Google::Auth::Credentials` base class to recognize the above flag in its toplevel factory methods and pass it down to Signet _if_ scopes are not overridden.
2. Fix a bug in `Google::Auth::Credentials` where setting credentials via a client-defined environment variable (e.g. `BIGTABLE_CREDENTIALS`) invoked a "raw" `Signet::OAuth2::Client` object rather than the subclass specific to the type of credential (e.g. `Google::Auth::ServiceAccountCredentials` or `Google::Auth::UserRefreshCredentials`). This prevented the self-signed JWT logic (and, incidentally, ID Token logic) from taking effect for those cases.

Tests have been updated to cover the above changes.

This PR should be rebased (not squashed) when merged, to preserve the two commits and their conventional commit descriptions.