### PR TITLE
feat: Credential parameters inherit from superclasses

### DIFF
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -41,6 +41,8 @@ module Google
     # In most cases, it is subclassed by API-specific credential classes that
     # can be instantiated by clients.
     #
+    # ## Options
+    #
     # Credentials classes are configured with options that generally dictate
     # default values for parameters such as scope and audience. These defaults
     # are expressed as class attributes, and may differ from endpoint to
@@ -52,6 +54,25 @@ module Google
     # Older users of this class may set options via constants. This usage is
     # deprecated. For example, instead of setting the `AUDIENCE` constant on
     # your subclass, call the `audience=` method.
+    #
+    # ## Example
+    #
+    #     class MyCredentials < Google::Auth::Credentials
+    #       # Set the default scope for these credentials
+    #       self.scope = "http://example.com/my_scope"
+    #     end
+    #
+    #     # creds is a credentials object suitable for Google API clients
+    #     creds = MyCredentials.default
+    #     creds.scope  # => ["http://example.com/my_scope"]
+    #
+    #     class SubCredentials < MyCredentials
+    #       # Override the default scope for this subclass
+    #       self.scope = "http://example.com/sub_scope"
+    #     end
+    #
+    #     creds2 = SubCredentials.default
+    #     creds2.scope  # => ["http://example.com/sub_scope"]
     #
     class Credentials
       ##

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -43,15 +43,16 @@ module Google
     #
     # ## Options
     #
-    # Credentials classes are configured with options that generally dictate
-    # default values for parameters such as scope and audience. These defaults
-    # are expressed as class attributes, and may differ from endpoint to
-    # endpoint. Thus, generally, subclasses are created specific to each
-    # endpoint, and configured with appropriate values. Note that these
-    # attributes inherit up the class hierarchy. If a particular attribute is
-    # not set for a subclass, its superclass is queried.
+    # Credentials classes are configured with options that dictate default
+    # values for parameters such as scope and audience. These defaults are
+    # expressed as class attributes, and may differ from endpoint to endpoint.
+    # Normally, an API client will provide subclasses specific to each
+    # endpoint, configured with appropriate values.
     #
-    # Older users of this class may set options via constants. This usage is
+    # Note that these options inherit up the class hierarchy. If a particular
+    # options is not set for a subclass, its superclass is queried.
+    #
+    # Some older users of this class set options via constants. This usage is
     # deprecated. For example, instead of setting the `AUDIENCE` constant on
     # your subclass, call the `audience=` method.
     #

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -166,9 +166,7 @@ module Google
           # Pull values when PATH_ENV_VARS or JSON_ENV_VARS constants exists.
           path_env_vars = const_get :PATH_ENV_VARS if const_defined? :PATH_ENV_VARS
           json_env_vars = const_get :JSON_ENV_VARS if const_defined? :JSON_ENV_VARS
-          if path_env_vars || json_env_vars
-            (Array(path_env_vars) + Array(json_env_vars)).flatten.uniq
-          end
+          (Array(path_env_vars) + Array(json_env_vars)).flatten.uniq if path_env_vars || json_env_vars
         end
       end
 


### PR DESCRIPTION
Cause class parameters on credential classes (such as scope) to inherit from superclasses if not set in the subclass. This makes setting these parameters via class methods, behave consistently with setting them as constants (which already inherit from superclasses by virtue of Ruby's constant lookup rules).

ref: https://github.com/googleapis/google-cloud-ruby/issues/8610
