### PR TITLE
fix: Fix crash when using a client credential without any paths or env_vars set

### DIFF
--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -82,6 +82,11 @@ describe Google::Auth::Credentials, :private do
     Google::Auth::Credentials.new default_keyfile_hash, scope: "http://example.com/scope"
   end
 
+  it "uses empty paths and env_vars by default" do
+    expect(Google::Auth::Credentials.paths).to eq([])
+    expect(Google::Auth::Credentials.env_vars).to eq([])
+  end
+
   describe "using CONSTANTS" do
     it "can be subclassed to pass in other env paths" do
       test_path_env_val = "/unknown/path/to/file.txt".freeze


### PR DESCRIPTION
We have some test cases in ruby-docs-samples that use Credentials classes without ever setting paths or env_vars. (This is not a valid production case, but we do run into it in some of our tests in other repos.) It causes an exception because the recent change to "inherit" these values from superclasses, causes the field to default to `nil` rather than the empty array. Fixed. Also updated the yardocs to make this more clear.