### PR TITLE
fix: Stop attempting to get the project from gcloud when applying self-signed JWTs

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -123,8 +123,10 @@ module Google
       def apply_self_signed_jwt! a_hash
         # Use the ServiceAccountJwtHeaderCredentials using the same cred values
         cred_json = {
-          private_key:  @signing_key.to_s,
-          client_email: @issuer
+          private_key: @signing_key.to_s,
+          client_email: @issuer,
+          project_id: @project_id,
+          quota_project_id: @quota_project_id
         }
         key_io = StringIO.new MultiJson.dump(cred_json)
         alt = ServiceAccountJwtHeaderCredentials.make_creds json_key_io: key_io


### PR DESCRIPTION
This was causing a significant slowdown when making self-signed JWT calls in an environment where gcloud is present.