### PR TITLE
chore: add library_type to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,4 @@
 {
-    "name": "googleauth",
     "language": "ruby",
     "distribution-name": "googleauth",
     "library_type": "AUTH"

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
     "name": "googleauth",
     "language": "ruby",
-    "distribution-name": "googleauth"
+    "distribution-name": "googleauth",
+    "library_type": "AUTH"
 }


### PR DESCRIPTION
Add an additional field called library_type to the .repo-metadata.json file. This is part of internal issue #184315365.