### PR TITLE
CredentialsLoader: close stdin and stderr to prevent reauth

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -175,7 +175,7 @@ module Google
       def load_gcloud_project_id
         gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
         gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
-        gcloud_json = IO.popen("#{gcloud} #{GCLOUD_CONFIG_COMMAND}", &:read)
+        gcloud_json = IO.popen("#{gcloud} #{GCLOUD_CONFIG_COMMAND}", in: :close, err: :close, &:read)
         config = MultiJson.load gcloud_json
         config["configuration"]["properties"]["core"]["project"]
       rescue StandardError


### PR DESCRIPTION
CredentialsLoader shells out to gcloud which causes a reauth prompt to
appear if the user's credentials have been expired. We should close
stdin and stderr so the shelling out silently fails and we return nil
instead.

If we don't do this we can randomly get prompts as follows:


```
Reauthentication required.
Please enter your password:
```