### PR TITLE
Add instructions for 3-legged-oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ drive.authorization = authorizer
 list_files = drive.list_files()
 ```
 
+### 3-Legged OAuth with a Service Account
+
+This is similar to regular service account authorization (see [this answer](https://support.google.com/a/answer/2538798?hl=en) for more details on the differences), but you'll need to indicate which user your service account is impersonating by manually updating the `sub` field.
+
+```ruby
+scope = 'https://www.googleapis.com/auth/androidpublisher'
+
+authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+  json_key_io: File.open('/path/to/service_account_json_key.json'),
+  scope: scope
+)
+authorizer.update!(sub: "email-to-impersonate@your-domain.com")
+
+authorizer.fetch_access_token!
+```
+
 ### Example (Environment Variables)
 
 ```bash


### PR DESCRIPTION
I spent a *long* time figuring out how to do this properly. The docs on
domain-wide delegation don't really make it clear that `sub` has to
be set in order to take advantage of those settings. It seems to me like
this is the easiest way to run domain-wide delegation with this gem, but
if there's an easier way I'm all ears!