### PR TITLE
docs: Fix sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ token_store = Google::Auth::Stores::FileTokenStore.new(
   :file => '/path/to/tokens.yaml')
 authorizer = Google::Auth::UserAuthorizer.new(client_id, scope, token_store)
 
+user_id = ENV['USER']
 credentials = authorizer.get_credentials(user_id)
 if credentials.nil?
   url = authorizer.get_authorization_url(base_url: OOB_URI )


### PR DESCRIPTION
closes: #351

I think it seems reasonable and simple to initialize `user_id` to `ENV['USER']` for this command-line example, but I am open to other ideas as well, such as using [Etc](https://ruby-doc.org/stdlib-3.0.2/libdoc/etc/rdoc/Etc.html).