### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.0"
             task: test , spec
+          - os: ubuntu-latest
+            ruby: "3.1"
+            task: test , spec
           - os: macos-latest
             ruby: "2.7"
             task: test , spec

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in googleauth.gemspec
 gemspec
 
-gem "coveralls", "~> 0.7"
+gem "coveralls", "~> 0.8"
 gem "fakefs", "~> 1.0"
 gem "fakeredis", "~> 0.5"
 gem "gems", "~> 1.2"


### PR DESCRIPTION
This PR adds an entry for Ruby 3.1 to the CI matrix.

In addition to that change, the version restriction on the Coveralls gem was upgraded from '~> 0.7' to '~> 0.8', mitigating errors seen in the Coveralls runs.

On my fork, when the CI config is updated to allow it, everything runs green.