### PR TITLE
fix: Support Faraday 2

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.platform = Gem::Platform::RUBY
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 3.a"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "memoist", "~> 0.16"
   gem.add_dependency "multi_json", "~> 1.11"


### PR DESCRIPTION
Relax the gemspec to allow dependency on Faraday 2.x.

Closes #355 