### PR TITLE
Squashed work of AWS support.

### DIFF
--- a/lib/googleauth/base_client.rb
+++ b/lib/googleauth/base_client.rb
@@ -1,0 +1,80 @@
+# Copyright 2023 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization
+  # used to access Google APIs.
+  module Auth
+    # BaseClient is a class used to contain common methods that are required by any
+    # Credentials Client, including AwsCredentials, ServiceAccountCredentials,
+    # and UserRefreshCredentials. This is a superclass of Signet::OAuth2::Client
+    # and has been created to create a generic interface for all credentials clients
+    # to use, including ones which do not inherit from Signet::OAuth2::Client.
+    module BaseClient
+      AUTH_METADATA_KEY = :authorization
+
+      # Updates a_hash updated with the authentication token
+      def apply! a_hash, opts = {}
+        # fetch the access token there is currently not one, or if the client
+        # has expired
+        fetch_access_token! opts if needs_access_token?
+        a_hash[AUTH_METADATA_KEY] = "Bearer #{send token_type}"
+      end
+
+      # Returns a clone of a_hash updated with the authentication token
+      def apply a_hash, opts = {}
+        a_copy = a_hash.clone
+        apply! a_copy, opts
+        a_copy
+      end
+
+      # Whether the id_token or access_token is missing or about to expire.
+      def needs_access_token?
+        send(token_type).nil? || expires_within?(60)
+      end
+
+      # Returns a reference to the #apply method, suitable for passing as
+      # a closure
+      def updater_proc
+        proc { |a_hash, opts = {}| apply a_hash, opts }
+      end
+
+      def on_refresh &block
+        @refresh_listeners = [] unless defined? @refresh_listeners
+        @refresh_listeners << block
+      end
+
+      def notify_refresh_listeners
+        listeners = defined?(@refresh_listeners) ? @refresh_listeners : []
+        listeners.each do |block|
+          block.call self
+        end
+      end
+
+      def expires_within?
+        raise NotImplementedError
+      end
+
+      private
+
+      def token_type
+        raise NotImplementedError
+      end
+
+      def fetch_access_token!
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -355,7 +355,7 @@ module Google
         @project_id = options["project_id"] || options["project"]
         @quota_project_id = options["quota_project_id"]
         case keyfile
-        when Signet::OAuth2::Client
+        when Signet::OAuth2::Client, Google::Auth::BaseClient
           update_from_signet keyfile
         when Hash
           update_from_hash keyfile, options

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -30,6 +30,11 @@ module Google
       REFRESH_TOKEN_VAR         = "GOOGLE_REFRESH_TOKEN".freeze
       ACCOUNT_TYPE_VAR          = "GOOGLE_ACCOUNT_TYPE".freeze
       PROJECT_ID_VAR            = "GOOGLE_PROJECT_ID".freeze
+      AWS_REGION_VAR            = "AWS_REGION".freeze
+      AWS_DEFAULT_REGION_VAR    = "AWS_DEFAULT_REGION".freeze
+      AWS_ACCESS_KEY_ID_VAR     = "AWS_ACCESS_KEY_ID".freeze
+      AWS_SECRET_ACCESS_KEY_VAR = "AWS_SECRET_ACCESS_KEY".freeze
+      AWS_SESSION_TOKEN_VAR     = "AWS_SESSION_TOKEN".freeze
       GCLOUD_POSIX_COMMAND      = "gcloud".freeze
       GCLOUD_WINDOWS_COMMAND    = "gcloud.cmd".freeze
       GCLOUD_CONFIG_COMMAND     = "config config-helper --format json --verbosity none".freeze

--- a/lib/googleauth/default_credentials.rb
+++ b/lib/googleauth/default_credentials.rb
@@ -18,6 +18,7 @@ require "stringio"
 require "googleauth/credentials_loader"
 require "googleauth/service_account"
 require "googleauth/user_refresh"
+require "googleauth/external_account"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -53,6 +54,8 @@ module Google
           ServiceAccountCredentials
         when "authorized_user"
           UserRefreshCredentials
+        when "external_account"
+          ExternalAccount::Credentials
         else
           raise "credentials type '#{type}' is not supported"
         end
@@ -69,6 +72,8 @@ module Google
           [json_key, ServiceAccountCredentials]
         when "authorized_user"
           [json_key, UserRefreshCredentials]
+        when "external_account"
+          [json_key, ExternalAccount::Credentials]
         else
           raise "credentials type '#{type}' is not supported"
         end

--- a/lib/googleauth/external_account.rb
+++ b/lib/googleauth/external_account.rb
@@ -1,0 +1,114 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "time"
+require "uri"
+require "googleauth/credentials_loader"
+require "googleauth/external_account/aws_credentials"
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization
+  # used to access Google APIs.
+  module Auth
+    # Authenticates requests using External Account credentials, such
+    # as those provided by the AWS provider.
+    module ExternalAccount
+      # Provides an entrypoint for all Exernal Account credential classes.
+      class Credentials
+        # The subject token type used for AWS external_account credentials.
+        attr_reader :project_id
+        attr_reader :quota_project_id
+
+        AWS_SUBJECT_TOKEN_TYPE = "urn:ietf:params:aws:token-type:aws4_request".freeze
+        AWS_SUBJECT_TOKEN_INVALID = "aws is the only currently supported external account type".freeze
+
+        TOKEN_URL_PATTERNS = [
+          /^[^.\s\/\\]+\.sts(?:\.mtls)?\.googleapis\.com$/.freeze,
+          /^sts(?:\.mtls)?\.googleapis\.com$/.freeze,
+          /^sts\.[^.\s\/\\]+(?:\.mtls)?\.googleapis\.com$/.freeze,
+          /^[^.\s\/\\]+-sts(?:\.mtls)?\.googleapis\.com$/.freeze,
+          /^sts-[^.\s\/\\]+\.p(?:\.mtls)?\.googleapis\.com$/.freeze
+        ].freeze
+
+        SERVICE_ACCOUNT_IMPERSONATION_URL_PATTERNS = [
+          /^[^.\s\/\\]+\.iamcredentials\.googleapis\.com$/.freeze,
+          /^iamcredentials\.googleapis\.com$/.freeze,
+          /^iamcredentials\.[^.\s\/\\]+\.googleapis\.com$/.freeze,
+          /^[^.\s\/\\]+-iamcredentials\.googleapis\.com$/.freeze,
+          /^iamcredentials-[^.\s\/\\]+\.p\.googleapis\.com$/.freeze
+        ].freeze
+
+        # Create a ExternalAccount::Credentials
+        #
+        # @param json_key_io [IO] an IO from which the JSON key can be read
+        # @param scope [string|array|nil] the scope(s) to access
+        def self.make_creds options = {}
+          json_key_io, scope = options.values_at :json_key_io, :scope
+
+          raise "A json file is required for external account credentials." unless json_key_io
+          user_creds = read_json_key json_key_io
+
+          raise "The provided token URL is invalid." unless is_token_url_valid? user_creds["token_url"]
+          unless is_service_account_impersonation_url_valid? user_creds["service_account_impersonation_url"]
+            raise "The provided service account impersonation url is invalid."
+          end
+
+          # TODO: check for other External Account Credential types. Currently only AWS is supported.
+          raise AWS_SUBJECT_TOKEN_INVALID unless user_creds["subject_token_type"] == AWS_SUBJECT_TOKEN_TYPE
+
+          Google::Auth::ExternalAccount::AwsCredentials.new(
+            audience: user_creds["audience"],
+            scope: scope,
+            subject_token_type: user_creds["subject_token_type"],
+            token_url: user_creds["token_url"],
+            credential_source: user_creds["credential_source"],
+            service_account_impersonation_url: user_creds["service_account_impersonation_url"]
+          )
+        end
+
+        # Reads the required fields from the JSON.
+        def self.read_json_key json_key_io
+          json_key = MultiJson.load json_key_io.read
+          wanted = [
+            "audience", "subject_token_type", "token_url", "credential_source"
+          ]
+          wanted.each do |key|
+            raise "the json is missing the #{key} field" unless json_key.key? key
+          end
+          json_key
+        end
+
+        def self.is_valid_url? url, valid_hostnames
+          begin
+            uri = URI(url)
+          rescue URI::InvalidURIError, ArgumentError
+            return false
+          end
+
+          return false unless uri.scheme == "https"
+
+          valid_hostnames.any? { |hostname| hostname =~ uri.host }
+        end
+
+        def self.is_token_url_valid? url
+          is_valid_url? url, TOKEN_URL_PATTERNS
+        end
+
+        def self.is_service_account_impersonation_url_valid? url
+          !url or is_valid_url? url, SERVICE_ACCOUNT_IMPERSONATION_URL_PATTERNS
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/external_account/aws_credentials.rb
+++ b/lib/googleauth/external_account/aws_credentials.rb
@@ -1,0 +1,381 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "time"
+require "googleauth/external_account/base_credentials"
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization
+  # used to access Google APIs.
+  module Auth
+    # Authenticates requests using External Account credentials, such
+    # as those provided by the AWS provider.
+    module ExternalAccount
+      # This module handles the retrieval of credentials from Google Cloud
+      # by utilizing the AWS EC2 metadata service and then exchanging the
+      # credentials for a short-lived Google Cloud access token.
+      class AwsCredentials
+        include Google::Auth::ExternalAccount::BaseCredentials
+        extend CredentialsLoader
+
+        # Will always be None, but method still gets used.
+        attr_reader :client_id
+
+        def initialize options = {}
+          base_setup options
+
+          @audience = options[:audience]
+          @credential_source = options[:credential_source] || {}
+          @environment_id = @credential_source["environment_id"]
+          @region_url = validate_metadata_server @credential_source["region_url"], "region_url"
+          @credential_verification_url = validate_metadata_server @credential_source["url"], "url"
+          @regional_cred_verification_url = @credential_source["regional_cred_verification_url"]
+          @imdsv2_session_token_url = validate_metadata_server @credential_source["imdsv2_session_token_url"],
+                                                               "imdsv2_session_token_url"
+
+          # These will be lazily loaded when needed, or will raise an error if not provided
+          @region = nil
+          @request_signer = nil
+        end
+
+        private
+
+        def validate_metadata_server url, name
+          return nil if url.nil?
+          host = URI(url).host
+          raise "Invalid host #{host} for #{name}." unless ["169.254.169.254", "[fd00:ec2::254]"].include? host
+          url
+        end
+
+        def get_aws_resource url, name, data: nil, headers: {}
+          begin
+            unless [nil, url].include? @imdsv2_session_token_url
+              headers["x-aws-ec2-metadata-token"] = get_aws_resource(
+                @imdsv2_session_token_url,
+                "Session Token",
+                headers: { "x-aws-ec2-metadata-token-ttl-seconds": "300" }
+              ).body
+            end
+
+            response = if data
+                         headers["Content-Type"] = "application/json"
+                         connection.post url, data, headers
+                       else
+                         connection.get url, nil, headers
+                       end
+
+            raise Faraday::Error unless response.success?
+            response
+          rescue Faraday::Error
+            raise "Failed to retrieve AWS #{name}."
+          end
+        end
+
+        # Retrieves the subject token using the credential_source object.
+        # The subject token is a serialized `AWS GetCallerIdentity signed request`_.
+        #
+        # The logic is summarized as:
+        #
+        # Retrieve the AWS region from the AWS_REGION or AWS_DEFAULT_REGION
+        # environment variable or from the AWS metadata server availability-zone
+        # if not found in the environment variable.
+        #
+        # Check AWS credentials in environment variables. If not found, retrieve
+        # from the AWS metadata server security-credentials endpoint.
+        #
+        # When retrieving AWS credentials from the metadata server
+        # security-credentials endpoint, the AWS role needs to be determined by
+        # calling the security-credentials endpoint without any argument. Then the
+        # credentials can be retrieved via: security-credentials/role_name
+        #
+        # Generate the signed request to AWS STS GetCallerIdentity action.
+        #
+        # Inject x-goog-cloud-target-resource into header and serialize the
+        # signed request. This will be the subject-token to pass to GCP STS.
+        #
+        # .. _AWS GetCallerIdentity signed request:
+        #     https://cloud.google.com/iam/docs/access-resources-aws#exchange-token
+        #
+        # Args:
+        #     request (google.auth.transport.Request): A callable used to make
+        #         HTTP requests.
+        #
+        # Returns:
+        #     str: The retrieved subject token.
+
+        def retrieve_subject_token!
+          if @request_signer.nil?
+            @region = region
+            @request_signer = AwsRequestSigner.new @region
+          end
+
+          request = {
+            method: "POST",
+            url: @regional_cred_verification_url.sub("{region}", @region)
+          }
+
+          request_options = @request_signer.generate_signed_request fetch_security_credentials, request
+
+          request_headers = request_options[:headers]
+          request_headers["x-goog-cloud-target-resource"] = @audience
+
+          aws_signed_request = {
+            headers: [],
+            method: request_options[:method],
+            url: request_options[:url]
+          }
+
+          aws_signed_request[:headers] = request_headers.keys.sort.map do |key|
+            { key: key, value: request_headers[key] }
+          end
+
+          uri_escape aws_signed_request.to_json
+        end
+
+        def uri_escape string
+          if string.nil?
+            nil
+          else
+            CGI.escape(string.encode("UTF-8")).gsub("+", "%20").gsub("%7E", "~")
+          end
+        end
+
+        # Retrieves the AWS security credentials required for signing AWS
+        # requests from either the AWS security credentials environment variables
+        # or from the AWS metadata server.
+        def fetch_security_credentials
+          env_aws_access_key_id = ENV[CredentialsLoader::AWS_ACCESS_KEY_ID_VAR]
+          env_aws_secret_access_key = ENV[CredentialsLoader::AWS_SECRET_ACCESS_KEY_VAR]
+          # This is normally not available for permanent credentials.
+          env_aws_session_token = ENV[CredentialsLoader::AWS_SESSION_TOKEN_VAR]
+
+          if env_aws_access_key_id && env_aws_secret_access_key
+            return {
+              access_key_id: env_aws_access_key_id,
+              secret_access_key: env_aws_secret_access_key,
+              session_token: env_aws_session_token
+            }
+          end
+
+          role_name = fetch_metadata_role_name
+          credentials = fetch_metadata_security_credentials role_name
+
+          {
+            access_key_id: credentials["AccessKeyId"],
+            secret_access_key: credentials["SecretAccessKey"],
+            session_token: credentials["Token"]
+          }
+        end
+
+        # Retrieves the AWS role currently attached to the current AWS
+        # workload by querying the AWS metadata server. This is needed for the
+        # AWS metadata server security credentials endpoint in order to retrieve
+        # the AWS security credentials needed to sign requests to AWS APIs.
+        def fetch_metadata_role_name
+          unless @credential_verification_url
+            raise "Unable to determine the AWS metadata server security credentials endpoint"
+          end
+
+          get_aws_resource(@credential_verification_url, "IAM Role").body
+        end
+
+        # Retrieves the AWS security credentials required for signing AWS
+        # requests from the AWS metadata server.
+        def fetch_metadata_security_credentials role_name
+          response = get_aws_resource "#{@credential_verification_url}/#{role_name}", "credentials"
+          MultiJson.load response.body
+        end
+
+        def region
+          @region = ENV[CredentialsLoader::AWS_REGION_VAR] || ENV[CredentialsLoader::AWS_DEFAULT_REGION_VAR]
+
+          unless @region
+            raise "region_url or region must be set for external account credentials" unless @region_url
+
+            @region ||= get_aws_resource(@region_url, "region").body[0..-2]
+          end
+
+          @region
+        end
+      end
+
+      # Implements an AWS request signer based on the AWS Signature Version 4 signing process.
+      # https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+      class AwsRequestSigner
+        # Instantiates an AWS request signer used to compute authenticated signed
+        # requests to AWS APIs based on the AWS Signature Version 4 signing process.
+        #
+        # @param [string] region_name
+        #     The AWS region to use.
+        def initialize region_name
+          @region_name = region_name
+        end
+
+        # Generates the signed request for the provided HTTP request for calling
+        # an AWS API. This follows the steps described at:
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+        #
+        # @param [Hash[string, string]] aws_security_credentials
+        #     A dictionary containing the AWS security credentials.
+        # @param [string] url
+        #     The AWS service URL containing the canonical URI and query string.
+        # @param [string] method
+        #     The HTTP method used to call this API.
+        #
+        # @return [hash[string, string]]
+        #     The AWS signed request dictionary object.
+        def generate_signed_request aws_credentials, original_request
+          uri = Addressable::URI.parse original_request[:url]
+          raise "Invalid AWS service URL" unless uri.hostname && uri.scheme == "https"
+          service_name = uri.host.split(".").first
+
+          datetime = Time.now.utc.strftime "%Y%m%dT%H%M%SZ"
+          date = datetime[0, 8]
+
+          headers = aws_headers aws_credentials, original_request, datetime
+
+          request_payload = original_request[:data] || ""
+          content_sha256 = sha256_hexdigest request_payload
+
+          canonical_req = canonical_request original_request[:method], uri, headers, content_sha256
+          sts = string_to_sign datetime, canonical_req, service_name
+
+          # Authorization header requires everything else to be properly setup in order to be properly
+          # calculated.
+          headers["Authorization"] = build_authorization_header headers, sts, aws_credentials, service_name, date
+
+          {
+            url: uri.to_s,
+            headers: headers,
+            method: original_request[:method],
+            data: (request_payload unless request_payload.empty?)
+          }.compact
+        end
+
+        private
+
+        def aws_headers aws_credentials, original_request, datetime
+          uri = Addressable::URI.parse original_request[:url]
+          temp_headers = original_request[:headers] || {}
+          headers = {}
+          temp_headers.each_key { |k| headers[k.to_s] = temp_headers[k] }
+          headers["host"] = uri.host
+          headers["x-amz-date"] = datetime
+          headers["x-amz-security-token"] = aws_credentials[:session_token] if aws_credentials[:session_token]
+          headers
+        end
+
+        def build_authorization_header headers, sts, aws_credentials, service_name, date
+          [
+            "AWS4-HMAC-SHA256",
+            "Credential=#{credential aws_credentials[:access_key_id], date, service_name},",
+            "SignedHeaders=#{headers.keys.sort.join ';'},",
+            "Signature=#{signature aws_credentials[:secret_access_key], date, sts, service_name}"
+          ].join(" ")
+        end
+
+        def signature secret_access_key, date, string_to_sign, service
+          k_date = hmac "AWS4#{secret_access_key}", date
+          k_region = hmac k_date, @region_name
+          k_service = hmac k_region, service
+          k_credentials = hmac k_service, "aws4_request"
+
+          hexhmac k_credentials, string_to_sign
+        end
+
+        def hmac key, value
+          OpenSSL::HMAC.digest OpenSSL::Digest.new("sha256"), key, value
+        end
+
+        def hexhmac key, value
+          OpenSSL::HMAC.hexdigest OpenSSL::Digest.new("sha256"), key, value
+        end
+
+        def credential access_key_id, date, service
+          "#{access_key_id}/#{credential_scope date, service}"
+        end
+
+        def credential_scope date, service
+          [
+            date,
+            @region_name,
+            service,
+            "aws4_request"
+          ].join("/")
+        end
+
+        def string_to_sign datetime, canonical_request, service
+          [
+            "AWS4-HMAC-SHA256",
+            datetime,
+            credential_scope(datetime[0, 8], service),
+            sha256_hexdigest(canonical_request)
+          ].join("\n")
+        end
+
+        def host uri
+          # Handles known and unknown URI schemes; default_port nil when unknown.
+          if uri.default_port == uri.port
+            uri.host
+          else
+            "#{uri.host}:#{uri.port}"
+          end
+        end
+
+        def canonical_request http_method, uri, headers, content_sha256
+          headers = headers.sort_by(&:first) # transforms to a sorted array of [key, value]
+
+          [
+            http_method,
+            uri.path.empty? ? "/" : uri.path,
+            build_canonical_querystring(uri.query || ""),
+            headers.map { |k, v| "#{k}:#{v}\n" }.join, # Canonical headers
+            headers.map(&:first).join(";"), # Signed headers
+            content_sha256
+          ].join("\n")
+        end
+
+        def sha256_hexdigest string
+          OpenSSL::Digest::SHA256.hexdigest string
+        end
+
+        # Generates the canonical query string given a raw query string.
+        # Logic is based on
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        # Code is from the AWS SDK for Ruby
+        # https://github.com/aws/aws-sdk-ruby/blob/0ac3d0a393ed216290bfb5f0383380376f6fb1f1/gems/aws-sigv4/lib/aws-sigv4/signer.rb#L532
+        def build_canonical_querystring query
+          params = query.split "&"
+          params = params.map { |p| p.match(/=/) ? p : "#{p}=" }
+
+          params.each.with_index.sort do |a, b|
+            a, a_offset = a
+            b, b_offset = b
+            a_name, a_value = a.split "="
+            b_name, b_value = b.split "="
+            if a_name == b_name
+              if a_value == b_value
+                a_offset <=> b_offset
+              else
+                a_value <=> b_value
+              end
+            else
+              a_name <=> b_name
+            end
+          end.map(&:first).join("&")
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/external_account/base_credentials.rb
+++ b/lib/googleauth/external_account/base_credentials.rb
@@ -1,0 +1,140 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.require "time"
+
+require "googleauth/base_client"
+require "googleauth/helpers/connection"
+require "googleauth/oauth2/sts_client"
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization
+  # used to access Google APIs.
+  module Auth
+    # Authenticates requests using External Account credentials, such
+    # as those provided by the AWS provider.
+    module ExternalAccount
+      # Authenticates requests using External Account credentials, such
+      # as those provided by the AWS provider.
+      module BaseCredentials
+        # Contains all methods needed for all external account credentials.
+        # Other credentials should call `base_setup` during initialization
+        # And should define the :retrieve_subject_token method
+        include BaseClient
+        include Helpers::Connection
+
+        attr_reader :expires_at
+        attr_accessor :access_token
+
+        def expires_within? seconds
+          # This method is needed for BaseClient
+          @expires_at && @expires_at - Time.now.utc < seconds
+        end
+
+        def expires_at= new_expires_at
+          @expires_at = normalize_timestamp new_expires_at
+        end
+
+        def fetch_access_token! _options = {}
+          # This method is needed for BaseClient
+          response = exchange_token
+
+          if @service_account_impersonation_url
+            impersonated_response = get_impersonated_access_token response["access_token"]
+            self.expires_at = impersonated_response["expireTime"]
+            self.access_token = impersonated_response["accessToken"]
+          else
+            # Extract the expiration time in seconds from the response and calculate the actual expiration time
+            # and then save that to the expiry variable.
+            self.expires_at = Time.now.utc + response["expires_in"].to_i
+            self.access_token = response["access_token"]
+          end
+
+          notify_refresh_listeners
+        end
+
+        private
+
+        STS_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange".freeze
+        STS_REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token".freeze
+        IAM_SCOPE = [
+          "https://www.googleapis.com/auth/iam".freeze
+        ].freeze
+
+        def token_type
+          # This method is needed for BaseClient
+          :access_token
+        end
+
+        def base_setup options
+          self.default_connection = options[:connection]
+
+          @audience = options[:audience]
+          @scope = options[:scope] || IAM_SCOPE
+          @subject_token_type = options[:subject_token_type]
+          @token_url = options[:token_url]
+          @service_account_impersonation_url = options[:service_account_impersonation_url]
+
+          @expires_at = nil
+          @access_token = nil
+
+          @sts_client = Google::Auth::OAuth2::STSClient.new(
+            token_exchange_endpoint: @token_url,
+            connection: default_connection
+          )
+        end
+
+        def normalize_timestamp time
+          case time
+          when NilClass
+            nil
+          when Time
+            time
+          when String
+            Time.parse time
+          else
+            raise "Invalid time value #{time}"
+          end
+        end
+
+        def exchange_token
+          @sts_client.exchange_token(
+            audience: @audience,
+            grant_type: STS_GRANT_TYPE,
+            subject_token: retrieve_subject_token!,
+            subject_token_type: @subject_token_type,
+            scopes: @service_account_impersonation_url ? IAM_SCOPE : @scope,
+            requested_token_type: STS_REQUESTED_TOKEN_TYPE
+          )
+        end
+
+        def get_impersonated_access_token token, _options = {}
+          response = connection.post @service_account_impersonation_url do |req|
+            req.headers["Authorization"] = "Bearer #{token}"
+            req.headers["Content-Type"] = "application/json"
+            req.body = MultiJson.dump({ scope: @scope })
+          end
+
+          if response.status != 200
+            raise "Service account impersonation failed with status #{response.status}"
+          end
+
+          MultiJson.load response.body
+        end
+
+        def retrieve_subject_token!
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/helpers/connection.rb
+++ b/lib/googleauth/helpers/connection.rb
@@ -1,0 +1,35 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "faraday"
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization
+  # used to access Google APIs.
+  module Auth
+    # Helpers provides utility methods for Google::Auth.
+    module Helpers
+      # Connection provides a Faraday connection for use with Google::Auth.
+      module Connection
+        module_function
+
+        attr_accessor :default_connection
+
+        def connection
+          @default_connection || Faraday.default_connection
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/oauth2/sts_client.rb
+++ b/lib/googleauth/oauth2/sts_client.rb
@@ -1,0 +1,99 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth/helpers/connection"
+
+module Google
+  module Auth
+    module OAuth2
+      # OAuth 2.0 Token Exchange Spec.
+      # This module defines a token exchange utility based on the `OAuth 2.0 Token
+      # Exchange`_ spec. This will be mainly used to exchange external credentials
+      # for GCP access tokens in workload identity pools to access Google APIs.
+      # The implementation will support various types of client authentication as
+      # allowed in the spec.
+      # A deviation on the spec will be for additional Google specific options that
+      # cannot be easily mapped to parameters defined in the RFC.
+      # The returned dictionary response will be based on the `rfc8693 section 2.2.1`_
+      # spec JSON response.
+      # .. _OAuth 2.0 Token Exchange: https://tools.ietf.org/html/rfc8693
+      # .. _rfc8693 section 2.2.1: https://tools.ietf.org/html/rfc8693#section-2.2.1
+      class STSClient
+        include Helpers::Connection
+
+        URLENCODED_HEADERS = { "Content-Type": "application/x-www-form-urlencoded" }.freeze
+
+        # Create a new instance of the STSClient.
+        #
+        # @param [String] token_exchange_endpoint
+        #  The token exchange endpoint.
+        def initialize options = {}
+          raise "Token exchange endpoint can not be nil" if options[:token_exchange_endpoint].nil?
+          self.default_connection = options[:connection]
+          @token_exchange_endpoint = options[:token_exchange_endpoint]
+        end
+
+        # Exchanges the provided token for another type of token based on the
+        # rfc8693 spec
+        #
+        # @param [Faraday instance] connection
+        # A callable faraday instance used to make HTTP requests.
+        # @param [String] grant_type
+        #   The OAuth 2.0 token exchange grant type.
+        # @param [String] subject_token
+        #   The OAuth 2.0 token exchange subject token.
+        # @param [String] subject_token_type
+        #   The OAuth 2.0 token exchange subject token type.
+        # @param [String] resource
+        #   The optional OAuth 2.0 token exchange resource field.
+        # @param [String] audience
+        #   The optional OAuth 2.0 token exchange audience field.
+        # @param [Array<String>] scopes
+        #   The optional list of scopes to use.
+        # @param [String] requested_token_type
+        #   The optional OAuth 2.0 token exchange requested token type.
+        # @param additional_headers (Hash<String,String>):
+        #   The optional additional headers to pass to the token exchange endpoint.
+        #
+        # @return [Hash] A hash containing the token exchange response.
+        def exchange_token options = {}
+          missing_required_opts = [:grant_type, :subject_token, :subject_token_type] - options.keys
+          unless missing_required_opts.empty?
+            raise ArgumentError, "Missing required options: #{missing_required_opts.join ', '}"
+          end
+
+          # TODO: Add the ability to add authentication to the headers
+          headers = URLENCODED_HEADERS.dup.merge(options[:additional_headers] || {})
+
+          request_body = {
+            grant_type: options[:grant_type],
+            audience: options[:audience],
+            scope: Array(options[:scopes])&.join(" ") || [],
+            requested_token_type: options[:requested_token_type],
+            subject_token: options[:subject_token],
+            subject_token_type: options[:subject_token_type]
+          }
+
+          response = connection.post @token_exchange_endpoint, URI.encode_www_form(request_body), headers
+
+          if response.status != 200
+            raise "Token exchange failed with status #{response.status}"
+          end
+
+          MultiJson.load response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -130,7 +130,7 @@ module Google
     # cf [Application Default Credentials](https://cloud.google.com/docs/authentication/production)
     class ServiceAccountJwtHeaderCredentials
       JWT_AUD_URI_KEY = :jwt_aud_uri
-      AUTH_METADATA_KEY = Signet::OAuth2::AUTH_METADATA_KEY
+      AUTH_METADATA_KEY = Signet::OAuth2::Client::AUTH_METADATA_KEY
       TOKEN_CRED_URI = "https://www.googleapis.com/oauth2/v4/token".freeze
       SIGNING_ALGORITHM = "RS256".freeze
       EXPIRY = 60

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -21,6 +21,7 @@ require "spec_helper"
 
 shared_examples "apply/apply! are OK" do
   let(:auth_key) { :authorization }
+  let(:extra_checks) {}
 
   # tests that use these examples need to define
   #
@@ -42,6 +43,8 @@ shared_examples "apply/apply! are OK" do
       @client.fetch_access_token!
       expect(@client.access_token).to eq(token)
       expect(access_stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should set id_token to the fetched value" do
@@ -50,6 +53,8 @@ shared_examples "apply/apply! are OK" do
       @id_client.fetch_access_token!
       expect(@id_client.id_token).to eq(token)
       expect(id_stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should notify refresh listeners after updating" do
@@ -61,6 +66,8 @@ shared_examples "apply/apply! are OK" do
                                access_token: "1/abcdef1234567890"
                              ))
       expect(access_stub).to have_been_requested
+
+      extra_checks
     end
   end
 
@@ -74,6 +81,8 @@ shared_examples "apply/apply! are OK" do
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(md).to eq(want)
       expect(stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should update the target hash with fetched ID token" do
@@ -86,6 +95,8 @@ shared_examples "apply/apply! are OK" do
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(md).to eq(want)
       expect(stub).to have_been_requested
+
+      extra_checks
     end
   end
 
@@ -99,6 +110,8 @@ shared_examples "apply/apply! are OK" do
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
       expect(stub).to have_been_requested
+
+      extra_checks
     end
   end
 
@@ -112,6 +125,8 @@ shared_examples "apply/apply! are OK" do
       want = { foo: "bar" }
       expect(md).to eq(want)
       expect(stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should add the token to the returned hash" do
@@ -123,6 +138,8 @@ shared_examples "apply/apply! are OK" do
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
       expect(stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should not fetch a new token if the current is not expired" do
@@ -137,6 +154,8 @@ shared_examples "apply/apply! are OK" do
         expect(got).to eq(want)
       end
       expect(stub).to have_been_requested
+
+      extra_checks
     end
 
     it "should fetch a new token if the current one is expired" do
@@ -151,6 +170,8 @@ shared_examples "apply/apply! are OK" do
         expect(got).to eq(want)
         @client.expires_at -= 3601 # default is to expire in 1hr
       end
+
+      extra_checks
     end
   end
 end

--- a/spec/googleauth/external_account/aws_credentials_spec.rb
+++ b/spec/googleauth/external_account/aws_credentials_spec.rb
@@ -1,0 +1,511 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec_dir = File.expand_path File.join(File.dirname(__FILE__))
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.uniq!
+
+require 'googleauth'
+require 'googleauth/apply_auth_examples'
+require 'googleauth/external_account/aws_credentials'
+require 'spec_helper'
+
+include Google::Auth::CredentialsLoader
+
+describe Google::Auth::ExternalAccount::AwsCredentials do
+  AwsCredentials = Google::Auth::ExternalAccount::AwsCredentials
+
+  before :each do
+   stub_const('ENV', {})
+  end
+
+  let :current_datetime do
+    Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+  end
+
+  let :expiry_datetime do
+    (Time.now + 3600).utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+  end
+
+  let(:credentials) { AwsCredentials.new(cred_json) }
+
+  let(:aws_metadata_role_name) { 'my-aws-metadata-role' }
+  let(:aws_region) { 'us-east-1c' }
+  let(:aws_access_key_id) { 'test' }
+  let(:aws_secret_access_key) { 'test' }
+  let(:aws_token) { 'test' }
+  let(:region_url) { 'http://169.254.169.254/latest/meta-data/placement/availability-zone' }
+  let(:security_credential_url) { 'http://169.254.169.254/latest/meta-data/iam/security-credentials' }
+  let(:regional_cred_verification_url) { 'https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15' }
+  let(:service_account_impersonation_url) { nil }
+  let(:imdsv2_url) { nil }
+  let(:imdsv2_token) { 'imdsv2_token' }
+
+  let :cred_json do
+    {
+      type: 'external_account',
+      audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+      subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
+      service_account_impersonation_url: service_account_impersonation_url,
+      token_url: 'https://sts.googleapis.com/v1/token',
+      credential_source: aws_credential_source
+    }.compact
+  end
+
+  let :aws_credential_source do
+    {
+      'environment_id' => 'aws1',
+      'region_url' => region_url,
+      'url' => security_credential_url,
+      'regional_cred_verification_url' => regional_cred_verification_url,
+      'imdsv2_session_token_url' => imdsv2_url
+    }.compact
+  end
+
+  let :aws_security_credentials_response do
+    {
+      Code: 'Success',
+      LastUpdated: current_datetime,
+      Type: 'AWS-HMAC',
+      AccessKeyId: aws_access_key_id,
+      SecretAccessKey: aws_secret_access_key,
+      Token: aws_token,
+      Expiration: expiry_datetime
+    }.compact
+  end
+
+  let :google_token_response do
+    {
+      "token_type" => "Bearer",
+      "expires_in" => 3600,
+      "issued_token_type" => "urn:ietf:params:aws:token-type:aws4_request",
+    }
+  end
+
+  let :google_token_impersonation_response do
+    {
+      accessToken: "test",
+      expireTime: expiry_datetime
+    }
+  end
+
+  let :basic_aws_headers do
+    {
+      'Accept'=>'*/*',
+      'Accept-Encoding'=>/.*/,
+      'User-Agent'=>/Faraday v\d+\.\d+\.\d+/
+    }
+  end
+
+  let :aws_headers do
+    headers = basic_aws_headers.clone
+    headers.merge!('x-aws-ec2-metadata-token' => imdsv2_token) if imdsv2_url
+    headers
+  end
+
+  let :metadata_role_endpoint do
+    return unless security_credential_url
+    stub_request(:get, security_credential_url)
+      .with(headers: aws_headers)
+  end
+
+  let :metadata_role_endpoint_success do
+    return unless security_credential_url
+    metadata_role_endpoint.to_return body: aws_metadata_role_name
+  end
+
+  let :metadata_role_endpoint_failure do
+    return unless security_credential_url
+    metadata_role_endpoint.to_return status: 400
+  end
+
+  let :security_credential_endpoint do
+    return unless security_credential_url and aws_metadata_role_name
+    stub_request(:get, "#{security_credential_url}/#{aws_metadata_role_name}")
+      .with(headers: aws_headers)
+  end
+
+  let :security_credential_endpoint_success do
+    return unless security_credential_url and aws_metadata_role_name
+    security_credential_endpoint.to_return(
+      body: MultiJson.dump(aws_security_credentials_response))
+  end
+
+  let :security_credential_endpoint_failure do
+    return unless security_credential_url and aws_metadata_role_name
+    security_credential_endpoint.to_return status: 400
+  end
+
+  let :region_endpoint do
+    return unless region_url
+    stub_request(:get, region_url)
+      .with(headers: aws_headers)
+  end
+
+  let :region_endpoint_success do
+    return unless region_url
+    region_endpoint.to_return body: aws_region
+  end
+
+  let :region_endpoint_failure do
+    return unless region_url
+    region_endpoint.to_return status: 400
+  end
+
+  let :imdsv2_endpoint do
+    return unless imdsv2_url
+    stub_request(:get, imdsv2_url)
+      .with(headers: basic_aws_headers.clone.merge(
+        'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'300'))
+  end
+
+  let :imdsv2_endpoint_success do
+    return unless imdsv2_url
+    imdsv2_endpoint.to_return body: imdsv2_token
+  end
+
+  let :imdsv2_endpoint_failure do
+    return unless imdsv2_url
+    imdsv2_endpoint.to_return status: 400
+  end
+
+  def impersonation_endpoint access_token
+    return unless access_token and service_account_impersonation_url
+    @impersonation_endpoint = stub_request(:post, service_account_impersonation_url)
+      .with(
+        body: "{\"scope\":[\"https://www.googleapis.com/auth/iam\"]}",
+        headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>/.*/,
+          'Authorization'=>"Bearer #{access_token}",
+          'Content-Type'=>'application/json',
+          'User-Agent'=>/Faraday v\d+\.\d+\.\d+/
+        })
+  end
+
+  def impersonation_endpoint_success access_token
+    return unless access_token and service_account_impersonation_url
+    impersonation_endpoint(access_token).to_return(
+      body: MultiJson.dump(google_token_impersonation_response.merge({
+        "accessToken" => access_token
+      }))
+    )
+  end
+
+  def impersonation_endpoint_failure access_token
+    return unless access_token and service_account_impersonation_url
+    impersonation_endpoint(access_token).to_return status: 400
+  end
+
+  def google_cred_endpoint
+    @token_endpoint = stub_request(:post, cred_json[:token_url])
+  end
+
+  def google_cred_endpoint_success access_token
+    google_cred_endpoint.to_return(
+      body: MultiJson.dump(google_token_response.merge({
+        "access_token" => access_token
+      }))
+    )
+  end
+
+  def google_cred_endpoint_failure
+    google_cred_endpoint.to_return status: 400
+  end
+
+  def make_auth_stubs opts
+    impersonation_endpoint_success opts[:access_token]
+    google_cred_endpoint_success opts[:access_token]
+  end
+
+  #####################
+  #
+  #  Test Cases
+  #
+  #####################
+
+  describe 'when AWS variables are provided via URLs' do
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'when AWS variables are provided via environment' do
+    let(:region_url) { nil }
+    before :example do
+      @client = credentials
+
+      ENV[AWS_REGION_VAR] = aws_region
+      ENV[AWS_ACCESS_KEY_ID_VAR] = aws_access_key_id
+      ENV[AWS_SECRET_ACCESS_KEY_VAR] = aws_secret_access_key
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'when AWS variables are provided via environment with default-region' do
+    let(:region_url) { nil }
+    before :example do
+      @client = credentials
+
+      ENV[AWS_DEFAULT_REGION_VAR] = aws_region
+      ENV[AWS_ACCESS_KEY_ID_VAR] = aws_access_key_id
+      ENV[AWS_SECRET_ACCESS_KEY_VAR] = aws_secret_access_key
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'when a region is not provided' do
+    let(:region_url) { nil }
+
+    before :example do
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it 'raises an error' do
+      make_auth_stubs access_token: 'token'
+      expect { credentials.fetch_access_token! }.to raise_error(/region_url or region must be set for external account credentials/)
+    end
+  end
+
+  describe 'when a security credentials are not provided' do
+    let(:security_credential_url) { nil }
+    before :example do
+      region_endpoint_success
+    end
+
+    it 'raises an error' do
+      make_auth_stubs access_token: 'token'
+      expect { credentials.fetch_access_token! }.to raise_error(/Unable to determine the AWS metadata server security credentials endpoint/)
+    end
+  end
+
+  describe 'with service account impersonation' do
+    let(:service_account_impersonation_url) { 'https://us-east1-iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-1234@service-name.iam.gserviceaccount.com:generateAccessToken'}
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK" do
+      let(:extra_checks) do
+        expect(@impersonation_endpoint).to have_been_requested.times(1)
+      end
+    end
+  end
+
+  describe 'with faulty service account impersonation' do
+    let(:service_account_impersonation_url) { 'https://us-east1-iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-1234@service-name.iam.gserviceaccount.com:generateAccessToken'}
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+      google_cred_endpoint_success 'token'
+      impersonation_endpoint_failure 'token'
+    end
+
+    it 'raises an error' do
+      expect { credentials.fetch_access_token! }.to raise_error(/Service account impersonation failed with status 400/)
+    end
+  end
+
+  describe 'with imdsv2' do
+    let(:imdsv2_url) { 'http://169.254.169.254/latest/api/token' }
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+      imdsv2_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK" do
+      let :extra_checks do
+        expect(imdsv2_endpoint).to have_been_requested.at_least_once
+      end
+    end
+  end
+
+  describe 'with imdsv2 and environment variables' do
+    let(:imdsv2_url) { 'http://169.254.169.254/latest/api/token' }
+
+    before :example do
+      @client = credentials
+
+      ENV[AWS_REGION_VAR] = aws_region
+      ENV[AWS_ACCESS_KEY_ID_VAR] = aws_access_key_id
+      ENV[AWS_SECRET_ACCESS_KEY_VAR] = aws_secret_access_key
+      # imdsv2 endpoint not set, but shouldn't be called
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'region failure' do
+    before :example do
+      region_endpoint_failure
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it 'raises an error' do
+      expect { credentials.fetch_access_token! }.to raise_error(/Failed to retrieve AWS region/)
+    end
+  end
+
+  describe 'IAM role failure' do
+    before :example do
+      region_endpoint_success
+      metadata_role_endpoint_failure
+    end
+
+    it 'raises an error' do
+      expect { credentials.fetch_access_token! }.to raise_error(/Failed to retrieve AWS IAM Role/)
+    end
+  end
+
+  describe 'AWS credential failure' do
+    before :example do
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_failure
+    end
+
+    it 'raises an error' do
+      expect { credentials.fetch_access_token! }.to raise_error(/Failed to retrieve AWS credential/)
+    end
+  end
+
+  describe 'ipv6 region url' do
+    let(:region_url) { 'http://[fd00:ec2::254]/latest/meta-data/placement/availability-zone' }
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'faulty ipv6 region url' do
+    let(:region_url) { 'http://fd00:ec2::254/latest/meta-data/placement/availability-zone' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/bad URI\(is not URI\?\): \"#{region_url}"/)
+    end
+  end
+
+  describe 'invalid region url' do
+    let(:region_url) { 'http://abc.com/latest/meta-data/placement/availability-zone' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/Invalid host abc\.com for region_url/)
+    end
+  end
+
+  describe 'ipv6 cred verification url' do
+    let(:security_credential_url) { 'http://[fd00:ec2::254]/latest/meta-data/iam/security-credentials' }
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'faulty ipv6 cred verification url' do
+    let(:security_credential_url) { 'http://fd00:ec2::254/latest/meta-data/iam/security-credentials' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/bad URI\(is not URI\?\): \"#{security_credential_url}"/)
+    end
+  end
+
+  describe 'invalid cred verification url' do
+    let(:security_credential_url) { 'http://abc.com/latest/meta-data/iam/security-credentials' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/Invalid host abc\.com for url/)
+    end
+  end
+
+  describe 'ipv6 imdsv2 url' do
+    let(:imdsv2_url) { 'http://[fd00:ec2::254]/latest/api/token' }
+
+    before :example do
+      @client = credentials
+
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+      imdsv2_endpoint_success
+    end
+
+    it_behaves_like "apply/apply! are OK"
+  end
+
+  describe 'faulty ipv6 imdsv2 url' do
+    let(:imdsv2_url) { 'http://fd00:ec2::254/latest/api/token' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/bad URI\(is not URI\?\): \"#{imdsv2_url}"/)
+    end
+  end
+
+  describe 'invalid imdsv2 url' do
+    let(:imdsv2_url) { 'http://abc.com/latest/api/token' }
+
+    it 'raises an error' do
+      expect { credentials }.to raise_error(/Invalid host abc\.com for imdsv2_session_token_url/)
+    end
+  end
+
+  describe 'regional cred verification url without ssl' do
+    let(:regional_cred_verification_url) { 'http://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15' }
+
+    before :example do
+      region_endpoint_success
+      metadata_role_endpoint_success
+      security_credential_endpoint_success
+    end
+
+    it 'raises an error' do
+      expect { credentials.fetch_access_token! }.to raise_error(/Invalid AWS service URL/)
+    end
+  end
+end

--- a/spec/googleauth/external_account/aws_request_signer_spec.rb
+++ b/spec/googleauth/external_account/aws_request_signer_spec.rb
@@ -1,0 +1,457 @@
+require 'googleauth/external_account/aws_credentials'
+
+describe Google::Auth::ExternalAccount::AwsRequestSigner do
+  AwsRequestSigner = Google::Auth::ExternalAccount::AwsRequestSigner
+
+  # Sample AWS security credentials to be used with tests that require a session token.
+  ACCESS_KEY_ID = 'ASIARD4OQDT6A77FR3CL'
+  SECRET_ACCESS_KEY = 'Y8AfSaucF37G4PpvfguKZ3/l7Id4uocLXxX0+VTx'
+  TOKEN = 'IQoJb3JpZ2luX2VjEIz//////////wEaCXVzLWVhc3QtMiJGMEQCIH7MHX/Oy/OB8OlLQa9GrqU1B914+iMikqWQW7vPCKlgAiA/Lsv8Jcafn14owfxXn95FURZNKaaphj0ykpmS+Ki+CSq0AwhlEAAaDDA3NzA3MTM5MTk5NiIMx9sAeP1ovlMTMKLjKpEDwuJQg41/QUKx0laTZYjPlQvjwSqS3OB9P1KAXPWSLkliVMMqaHqelvMF/WO/glv3KwuTfQsavRNs3v5pcSEm4SPO3l7mCs7KrQUHwGP0neZhIKxEXy+Ls//1C/Bqt53NL+LSbaGv6RPHaX82laz2qElphg95aVLdYgIFY6JWV5fzyjgnhz0DQmy62/Vi8pNcM2/VnxeCQ8CC8dRDSt52ry2v+nc77vstuI9xV5k8mPtnaPoJDRANh0bjwY5Sdwkbp+mGRUJBAQRlNgHUJusefXQgVKBCiyJY4w3Csd8Bgj9IyDV+Azuy1jQqfFZWgP68LSz5bURyIjlWDQunO82stZ0BgplKKAa/KJHBPCp8Qi6i99uy7qh76FQAqgVTsnDuU6fGpHDcsDSGoCls2HgZjZFPeOj8mmRhFk1Xqvkbjuz8V1cJk54d3gIJvQt8gD2D6yJQZecnuGWd5K2e2HohvCc8Fc9kBl1300nUJPV+k4tr/A5R/0QfEKOZL1/k5lf1g9CREnrM8LVkGxCgdYMxLQow1uTL+QU67AHRRSp5PhhGX4Rek+01vdYSnJCMaPhSEgcLqDlQkhk6MPsyT91QMXcWmyO+cAZwUPwnRamFepuP4K8k2KVXs/LIJHLELwAZ0ekyaS7CptgOqS7uaSTFG3U+vzFZLEnGvWQ7y9IPNQZ+Dffgh4p3vF4J68y9049sI6Sr5d5wbKkcbm8hdCDHZcv4lnqohquPirLiFQ3q7B17V9krMPu3mz1cg4Ekgcrn/E09NTsxAqD8NcZ7C7ECom9r+X3zkDOxaajW6hu3Az8hGlyylDaMiFfRbBJpTIlxp7jfa7CxikNgNtEKLH9iCzvuSg2vhA=='
+  # To avoid json.dumps() differing behavior from one version to other,
+  # the JSON payload is hardcoded.
+  REQUEST_PARAMS = '{"KeySchema":[{"KeyType":"HASH","AttributeName":"Id"}],"TableName":"TestTable","AttributeDefinitions":[{"AttributeName":"Id","AttributeType":"S"}],"ProvisionedThroughput":{"WriteCapacityUnits":5,"ReadCapacityUnits":5}}'
+
+  TEST_FIXTURES = [
+    # GET request (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with relative path (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-relative-relative.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-relative-relative.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/foo/bar/../..',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/foo/bar/../..',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with /./ path (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-slash-dot-slash.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-slash-dot-slash.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/./',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/./',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b27ccfbfa7df52a200ff74193ca6e32d4b48b8856fab7ebf1c595d0670a7e470',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with pointless dot path (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-slash-pointless-dot.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-slash-pointless-dot.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/./foo',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/./foo',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=910e4d6c9abafaf87898e1eb4c929135782ea25bb0279703146455745391e63a',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with utf8 path (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-utf8.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-utf8.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/%E1%88%B4',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/%E1%88%B4',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=8d6634c189aa8c75c2e51e106b6b5121bed103fdb351f7d7d4381c738823af74',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with duplicate query key (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-query-order-key-case.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-query-order-key-case.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/?foo=Zoo&foo=aha',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/?foo=Zoo&foo=aha',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=be7148d34ebccdc6423b19085378aa0bee970bdc61d144bd1a8c48c33079ab09',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with duplicate out of order query key (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-query-order-value.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-query-order-value.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://host.foo.com/?foo=b&foo=a',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/?foo=b&foo=a',
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=feb926e49e382bec75c9d7dcb2a1b6dc8aa50ca43c25d2bc51143768c0875acc',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with utf8 query (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-ut8-query.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-vanilla-ut8-query.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'GET',
+            url: "https://host.foo.com/?#{CGI.unescape('%E1%88%B4')}=bar",
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: "https://host.foo.com/?#{CGI.unescape('%E1%88%B4')}=bar",
+            method: 'GET',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=6fb359e9a05394cc7074e0feb42573a2601abc0c869a953e8c5c12e4e01f1a8c',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # POST request with sorted headers (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-header-key-sort.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-header-key-sort.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://host.foo.com/',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT', 'ZOO': 'zoobar'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/',
+            method: 'POST',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=b7a95a52518abbca0964a999a880429ab734f35ebbf1235bd79a5de87756dc4a',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+                'ZOO': 'zoobar',
+            },
+        },
+    },
+    # POST request with upper case header value from AWS Python test harness.
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-header-value-case.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-header-value-case.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://host.foo.com/',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT', 'zoo': 'ZOOBAR'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/',
+            method: 'POST',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;zoo, Signature=273313af9d0c265c531e11db70bbd653f3ba074c1009239e8559d3987039cad7',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+                'zoo': 'ZOOBAR',
+            },
+        },
+    },
+    # POST request with header and no body (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-header-value-trim.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/get-header-value-trim.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://host.foo.com/',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT', 'p': 'phfft'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/',
+            method: 'POST',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host;p, Signature=debf546796015d6f6ded8626f5ce98597c33b47b9164cf6b17b4642036fcb592',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+                'p': 'phfft',
+            },
+        },
+    },
+    # POST request with body and no header (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-x-www-form-urlencoded.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-x-www-form-urlencoded.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://host.foo.com/',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+            data: 'foo=bar',
+        },
+        signed_request: {
+            url: 'https://host.foo.com/',
+            method: 'POST',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=content-type;date;host, Signature=5a15b22cf462f047318703b92e6f4f38884e4a7ab7b1d6426ca46a8bd1c26cbc',
+                'host': 'host.foo.com',
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+            data: 'foo=bar',
+        },
+    },
+    # POST request with querystring (AWS botocore tests).
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-vanilla-query.req
+    # https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/tests/unit/auth/aws4_testsuite/post-vanilla-query.sreq
+    {
+        region: 'us-east-1',
+        time: '2011-09-09T23:36:00Z',
+        credentials: {
+            access_key_id: 'AKIDEXAMPLE',
+            secret_access_key: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://host.foo.com/?foo=bar',
+            headers: {'date': 'Mon, 09 Sep 2011 23:36:00 GMT'},
+        },
+        signed_request: {
+            url: 'https://host.foo.com/?foo=bar',
+            method: 'POST',
+            headers: {
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=date;host, Signature=b6e3b79003ce0743a491606ba1035a804593b0efb1e20a11cba83f8c25a57a92',
+                'host': 'host.foo.com',
+                'date': 'Mon, 09 Sep 2011 23:36:00 GMT',
+            },
+        },
+    },
+    # GET request with session token credentials.
+    {
+        region: 'us-east-2',
+        time: '2020-08-11T06:55:22Z',
+        credentials: {
+            access_key_id: ACCESS_KEY_ID,
+            secret_access_key: SECRET_ACCESS_KEY,
+            security_token: TOKEN,
+        },
+        original_request: {
+            method: 'GET',
+            url: 'https://ec2.us-east-2.amazonaws.com?Action=DescribeRegions&Version=2013-10-15',
+        },
+        signed_request: {
+            url: 'https://ec2.us-east-2.amazonaws.com?Action=DescribeRegions&Version=2013-10-15',
+            method: 'GET',
+            headers: {
+                'Authorization': "AWS4-HMAC-SHA256 Credential=#{ACCESS_KEY_ID}/20200811/us-east-2/ec2/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=631ea80cddfaa545fdadb120dc92c9f18166e38a5c47b50fab9fce476e022855",
+                'host': 'ec2.us-east-2.amazonaws.com',
+                'x-amz-date': '20200811T065522Z',
+                'x-amz-security-token': TOKEN,
+            },
+        },
+    },
+    # POST request with session token credentials.
+    {
+        region: 'us-east-2',
+        time: '2020-08-11T06:55:22Z',
+        credentials: {
+            access_key_id: ACCESS_KEY_ID,
+            secret_access_key: SECRET_ACCESS_KEY,
+            security_token: TOKEN,
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15',
+        },
+        signed_request: {
+            url: 'https://sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15',
+            method: 'POST',
+            headers: {
+                'Authorization': "AWS4-HMAC-SHA256 Credential=#{ACCESS_KEY_ID}/20200811/us-east-2/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=73452984e4a880ffdc5c392355733ec3f5ba310d5e0609a89244440cadfe7a7a",
+                'host': 'sts.us-east-2.amazonaws.com',
+                'x-amz-date': '20200811T065522Z',
+                'x-amz-security-token': TOKEN,
+            },
+        },
+    },
+    # POST request with computed x-amz-date and no data.
+    {
+        region: 'us-east-2',
+        time: '2020-08-11T06:55:22Z',
+        credentials: {'access_key_id': ACCESS_KEY_ID, 'secret_access_key': SECRET_ACCESS_KEY},
+        original_request: {
+            method: 'POST',
+            url: 'https://sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15',
+        },
+        signed_request: {
+            url: 'https://sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15',
+            method: 'POST',
+            headers: {
+                'Authorization': "AWS4-HMAC-SHA256 Credential=#{ACCESS_KEY_ID}/20200811/us-east-2/sts/aws4_request, SignedHeaders=host;x-amz-date, Signature=d095ba304919cd0d5570ba8a3787884ee78b860f268ed040ba23831d55536d56",
+                'host': 'sts.us-east-2.amazonaws.com',
+                'x-amz-date': '20200811T065522Z',
+            },
+        },
+    },
+    # POST request with session token and additional headers/data.
+    {
+        region: 'us-east-2',
+        time: '2020-08-11T06:55:22Z',
+        credentials: {
+            access_key_id: ACCESS_KEY_ID,
+            secret_access_key: SECRET_ACCESS_KEY,
+            security_token: TOKEN,
+        },
+        original_request: {
+            method: 'POST',
+            url: 'https://dynamodb.us-east-2.amazonaws.com/',
+            headers: {
+                'Content-Type': 'application/x-amz-json-1.0',
+                'x-amz-target': 'DynamoDB_20120810.CreateTable',
+            },
+            data: REQUEST_PARAMS,
+        },
+        signed_request: {
+            url: 'https://dynamodb.us-east-2.amazonaws.com/',
+            method: 'POST',
+            headers: {
+                'Authorization': "AWS4-HMAC-SHA256 Credential=#{ACCESS_KEY_ID}/20200811/us-east-2/dynamodb/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=fdaa5b9cc9c86b80fe61eaf504141c0b3523780349120f2bd8145448456e0385",
+                'host': 'dynamodb.us-east-2.amazonaws.com',
+                'x-amz-date': '20200811T065522Z',
+                'Content-Type': 'application/x-amz-json-1.0',
+                'x-amz-target': 'DynamoDB_20120810.CreateTable',
+                'x-amz-security-token': TOKEN,
+            },
+            data: REQUEST_PARAMS,
+        },
+    },
+]
+
+  TEST_FIXTURES.each.with_index do |fixture, index|
+    it "fulfils Amazon's test \##{index}" do
+      allow(Time).to receive(:now).and_return(Time.strptime(fixture[:time], '%Y-%m-%dT%H:%M:%SZ'))
+      request_signer = AwsRequestSigner.new(fixture[:region])
+      actual_signed_request = request_signer.generate_signed_request(fixture[:credentials], fixture[:original_request])
+    end
+  end
+end

--- a/spec/googleauth/external_account_spec.rb
+++ b/spec/googleauth/external_account_spec.rb
@@ -1,0 +1,228 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'googleauth'
+require 'googleauth/apply_auth_examples'
+require 'googleauth/external_account'
+require 'spec_helper'
+require 'tempfile'
+
+describe Google::Auth::ExternalAccount::Credentials do
+  describe :is_token_url_valid? do
+    VALID_URLS = [
+      "https://sts.googleapis.com",
+      "https://sts.mtls.googleapis.com",
+      "https://us-east-1.sts.googleapis.com",
+      "https://us-east-1.sts.mtls.googleapis.com",
+      "https://US-EAST-1.sts.googleapis.com",
+      "https://sts.us-east-1.googleapis.com",
+      "https://sts.US-WEST-1.googleapis.com",
+      "https://us-east-1-sts.googleapis.com",
+      "https://US-WEST-1-sts.googleapis.com",
+      "https://US-WEST-1-sts.mtls.googleapis.com",
+      "https://us-west-1-sts.googleapis.com/path?query",
+      "https://sts-us-east-1.p.googleapis.com",
+      "https://sts-us-east-1.p.mtls.googleapis.com",
+    ]
+
+    INVALID_URLS = [
+      nil,
+      "https://iamcredentials.googleapis.com",
+      "https://mtls.iamcredentials.googleapis.com",
+      "sts.googleapis.com",
+      "mtls.sts.googleapis.com",
+      "mtls.googleapis.com",
+      "https://",
+      "http://sts.googleapis.com",
+      "https://st.s.googleapis.com",
+      "https://us-eas\t-1.sts.googleapis.com",
+      "https:/us-east-1.sts.googleapis.com",
+      "https:/us-east-1.mtls.sts.googleapis.com",
+      "https://US-WE/ST-1-sts.googleapis.com",
+      "https://sts-us-east-1.googleapis.com",
+      "https://sts-US-WEST-1.googleapis.com",
+      "testhttps://us-east-1.sts.googleapis.com",
+      "https://us-east-1.sts.googleapis.comevil.com",
+      "https://us-east-1.us-east-1.sts.googleapis.com",
+      "https://us-ea.s.t.sts.googleapis.com",
+      "https://sts.googleapis.comevil.com",
+      "hhttps://us-east-1.sts.googleapis.com",
+      "https://us- -1.sts.googleapis.com",
+      "https://-sts.googleapis.com",
+      "https://-mtls.googleapis.com",
+      "https://us-east-1.sts.googleapis.com.evil.com",
+      "https://sts.pgoogleapis.com",
+      "https://p.googleapis.com",
+      "https://sts.p.com",
+      "https://sts.p.mtls.com",
+      "http://sts.p.googleapis.com",
+      "https://xyz-sts.p.googleapis.com",
+      "https://sts-xyz.123.p.googleapis.com",
+      "https://sts-xyz.p1.googleapis.com",
+      "https://sts-xyz.p.foo.com",
+      "https://sts-xyz.p.foo.googleapis.com",
+      "https://sts-xyz.mtls.p.foo.googleapis.com",
+      "https://sts-xyz.p.mtls.foo.googleapis.com",
+    ]
+
+    VALID_URLS.each do |token_url|
+      describe token_url do
+        it 'is valid' do
+          expect(Google::Auth::ExternalAccount::Credentials.is_token_url_valid?(token_url)).to be(true)
+        end
+      end
+    end
+
+    INVALID_URLS.each do |token_url|
+      describe token_url do
+        it 'is invalid' do
+          expect(Google::Auth::ExternalAccount::Credentials.is_token_url_valid?(token_url)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe :is_service_account_impersonation_url_valid? do
+    VALID_URLS = [
+      nil,
+      "https://iamcredentials.googleapis.com",
+      "https://us-east-1.iamcredentials.googleapis.com",
+      "https://US-EAST-1.iamcredentials.googleapis.com",
+      "https://iamcredentials.us-east-1.googleapis.com",
+      "https://iamcredentials.US-WEST-1.googleapis.com",
+      "https://us-east-1-iamcredentials.googleapis.com",
+      "https://US-WEST-1-iamcredentials.googleapis.com",
+      "https://us-west-1-iamcredentials.googleapis.com/path?query",
+      "https://iamcredentials-us-east-1.p.googleapis.com",
+    ]
+    INVALID_URLS = [
+      "https://sts.googleapis.com",
+      "iamcredentials.googleapis.com",
+      "https://",
+      "http://iamcredentials.googleapis.com",
+      "https://iamcre.dentials.googleapis.com",
+      "https://us-eas\t-1.iamcredentials.googleapis.com",
+      "https:/us-east-1.iamcredentials.googleapis.com",
+      "https://US-WE/ST-1-iamcredentials.googleapis.com",
+      "https://iamcredentials-us-east-1.googleapis.com",
+      "https://iamcredentials-US-WEST-1.googleapis.com",
+      "testhttps://us-east-1.iamcredentials.googleapis.com",
+      "https://us-east-1.iamcredentials.googleapis.comevil.com",
+      "https://us-east-1.us-east-1.iamcredentials.googleapis.com",
+      "https://us-ea.s.t.iamcredentials.googleapis.com",
+      "https://iamcredentials.googleapis.comevil.com",
+      "hhttps://us-east-1.iamcredentials.googleapis.com",
+      "https://us- -1.iamcredentials.googleapis.com",
+      "https://-iamcredentials.googleapis.com",
+      "https://us-east-1.iamcredentials.googleapis.com.evil.com",
+      "https://iamcredentials.pgoogleapis.com",
+      "https://p.googleapis.com",
+      "https://iamcredentials.p.com",
+      "http://iamcredentials.p.googleapis.com",
+      "https://xyz-iamcredentials.p.googleapis.com",
+      "https://iamcredentials-xyz.123.p.googleapis.com",
+      "https://iamcredentials-xyz.p1.googleapis.com",
+      "https://iamcredentials-xyz.p.foo.com",
+      "https://iamcredentials-xyz.p.foo.googleapis.com",
+    ]
+
+    VALID_URLS.each do |impersonation_url|
+      describe impersonation_url do
+        it 'is valid' do
+          expect(Google::Auth::ExternalAccount::Credentials.is_service_account_impersonation_url_valid?(impersonation_url)).to be(true)
+        end
+      end
+    end
+
+    INVALID_URLS.each do |impersonation_url|
+      describe impersonation_url do
+        it 'is invalid' do
+          expect(Google::Auth::ExternalAccount::Credentials.is_service_account_impersonation_url_valid?(impersonation_url)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe :make_creds do
+    it 'should be able to make aws credentials' do
+      f = Tempfile.new('aws')
+      begin
+        f.write(MultiJson.dump({
+          type: 'external_account',
+          audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+          subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
+          token_url: 'https://sts.googleapis.com/v1/token',
+          credential_source: {
+            'environment_id' => 'aws1',
+            'region_url' => 'http://169.254.169.254/latest/meta-data/placement/availability-zone',
+            'url' => 'http://169.254.169.254/latest/meta-data/iam/security-credentials',
+            'regional_cred_verification_url' => 'https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15',
+          }
+        }))
+        f.rewind
+        expect(Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f)).to be_a(Google::Auth::ExternalAccount::AwsCredentials)
+      ensure
+        f.close
+        f.unlink
+      end
+    end
+
+    [:audience, :subject_token_type, :token_url, :credential_source].each do |field|
+      it "should raise an error when missing the #{field} field" do
+        f = Tempfile.new('missing')
+        begin
+          creds = {
+            type: 'external_account',
+            audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+            subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+            token_url: 'https://sts.googleapis.com/v1/token',
+            credential_source: {},
+          }
+          creds.delete(field)
+          f.write(MultiJson.dump(creds))
+          f.rewind
+          expect { Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f) }.to raise_error(/the json is missing the #{field} field/)
+        ensure
+          f.close
+          f.unlink
+        end
+      end
+    end
+
+    it 'should raise an error for invalid credentials' do
+      f = Tempfile.new('invalid')
+      begin
+        f.write(MultiJson.dump({
+          type: 'external_account',
+          audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+          subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+          token_url: 'https://sts.googleapis.com/v1/token',
+          credential_source: {},
+        }))
+        f.rewind
+        expect { Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f) }.to raise_error(/aws is the only currently supported external account type/)
+      ensure
+        f.close
+        f.unlink
+      end
+    end
+
+    it 'should raise an error if called incorrectly' do
+      expect { Google::Auth::ExternalAccount::Credentials.make_creds({
+        type: 'external_account',
+        audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+      }) }.to raise_error(/A json file is required for external account credentials./)
+    end
+  end
+end

--- a/spec/googleauth/oauth2/sts_client_spec.rb
+++ b/spec/googleauth/oauth2/sts_client_spec.rb
@@ -1,0 +1,86 @@
+# Copyright 2022 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth"
+require "googleauth/oauth2/sts_client"
+require "spec_helper"
+
+spec_dir = File.expand_path File.join(File.dirname(__FILE__))
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.uniq!
+
+describe Google::Auth::OAuth2::STSClient do
+  GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange".freeze
+  RESOURCE = "https://api.example.com/".freeze
+  AUDIENCE = "urn:example:cooperation-context".freeze
+  REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token".freeze
+  SUBJECT_TOKEN = "HEADER.SUBJECT_TOKEN_PAYLOAD.SIGNATURE".freeze
+  SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt".freeze
+  TOKEN_EXCHANGE_ENDPOINT = "https://example.com/token.oauth2".freeze
+  SUCCESS_RESPONSE = {
+      "access_token": "ACCESS_TOKEN",
+      "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+      "token_type": "Bearer",
+      "expires_in": 3600,
+      "scope": "scope1 scope2",
+  }.freeze
+  ERROR_RESPONSE = {
+      "error": "invalid_request",
+      "error_description": "Invalid subject token",
+      "error_uri": "https://tools.ietf.org/html/rfc6749",
+  }.freeze
+
+  context "with valid parameters" do
+    let :sts_client do
+      Google::Auth::OAuth2::STSClient.new({token_exchange_endpoint: TOKEN_EXCHANGE_ENDPOINT})
+    end
+
+    it 'should successfully exchange a token with only required parameters' do
+      stub_request(:post, TOKEN_EXCHANGE_ENDPOINT).to_return(status: 200, body: SUCCESS_RESPONSE.to_json)
+
+      res = sts_client.exchange_token({
+        grant_type: GRANT_TYPE,
+        subject_token: SUBJECT_TOKEN,
+        subject_token_type: SUBJECT_TOKEN_TYPE,
+        audience: AUDIENCE,
+        requested_token_type: REQUESTED_TOKEN_TYPE
+      })
+
+      expect(res["access_token"]).to eq(SUCCESS_RESPONSE[:access_token])
+    end
+
+    it 'should appropriately handle an error response' do
+      stub_request(:post, TOKEN_EXCHANGE_ENDPOINT).to_return(status: 400, body: ERROR_RESPONSE.to_json)
+
+      # Expect an exception to be raised
+      expect {
+        sts_client.exchange_token({
+          grant_type: GRANT_TYPE,
+          subject_token: SUBJECT_TOKEN,
+          subject_token_type: SUBJECT_TOKEN_TYPE,
+          audience: AUDIENCE,
+          requested_token_type: REQUESTED_TOKEN_TYPE
+        })
+      }.to raise_error(/Token exchange failed with status 400/)
+    end
+  end
+
+  context "with invalid parameters" do
+    it 'should raise an error if the token exchange endpoint is not provided' do
+      expect {
+        Google::Auth::OAuth2::STSClient.new
+      }.to raise_error(/Token exchange endpoint can not be nil/)
+    end
+  end
+end


### PR DESCRIPTION
* feat: Add External Account Credential support as well as support for impersonated credential

* chore: Add tests for ExternalAccount, add methods required to make test compatible with apply_auth_examples. ExternalAccount was not fully compatible with the other providers, this brings it in line and moves some common methods between the other provides and ExternalAccount into a module which is now included by the AWSClient provider and Signet::Auth::Client

* chore: Move AWS Credentials to their own file, do not pass role from external account, create dedicated Connection helper module, other misc PR cleanup

* chore: Update BaseClient documentation comment

* chore: Ensure the subject token type matches AWS before building AwsCredentials

* feat: perform validation and add tests

* Fixes to get manual testing working

* dates

* fixes

* Allow different versions of Faraday

* ALlow different versions of Faraday

* chore: use SampleLoader for running sample tests (#411)

* address the comments

---------