### PR TITLE
AWS Federation IMDSv2 tokens must be requested by PUT method

### DIFF
--- a/spec/googleauth/external_account/aws_credentials_spec.rb
+++ b/spec/googleauth/external_account/aws_credentials_spec.rb
@@ -165,7 +165,7 @@ describe Google::Auth::ExternalAccount::AwsCredentials do
 
   let :imdsv2_endpoint do
     return unless imdsv2_url
-    stub_request(:get, imdsv2_url)
+    stub_request(:put, imdsv2_url)
       .with(headers: basic_aws_headers.clone.merge(
         'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'300'))
   end


### PR DESCRIPTION
Currently, the following error occurs when the AWS federation is used in EC2 instance that requires IMDSv2:
```
/home/ec2-user/.local/share/gem/ruby/gems/googleauth-1.5.0/lib/googleauth/external_account/aws_credentials.rb:135:in `rescue in get_aws_resource': Failed to retrieve AWS Session Token. (RuntimeError)
```

This is due to the session token endpoint only accepts the PUT method:

```
$ curl -v "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300"
*   Trying 169.254.169.254:80...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/api/token HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.88.1
> Accept: */*
> X-aws-ec2-metadata-token-ttl-seconds: 21600
>
< HTTP/1.1 405 Not Allowed
< Allow: OPTIONS, PUT
...
```

This fixes the issue by making the library to request the session token using PUT methods.