### PR TITLE
fix: GCECredentials - Allow retrieval of ID token

### DIFF
--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -60,7 +60,7 @@ module Google
         GCECredentials.unmemoize_all
         raise NOT_FOUND_ERROR
       end
-      GCECredentials.new scope: scope
+      GCECredentials.new options.merge(scope: scope)
     end
   end
 end


### PR DESCRIPTION
**CONTEXT:** 

While deploying a couple of services on `Cloud RUN`:
1. service A running with service account A
2. service B running with service account B
3. I added `roles/run.invoker` for service account B on service A.

I expected to be able to retrieve an ID token and be able to call service A from service B. After some debugging I realised I was getting an `access_token` rather then an `id_token`.
I tracked it down to the GCECredentials instantiation only passing the scope to the subclass of the [Signet::Oauth2::Client](https://github.com/googleapis/signet/blob/main/lib/signet/oauth_2/client.rb#L95), hence not being able to pass the `target_audience` for retrieve an `id_token`

I believe this should fix: https://github.com/googleapis/google-auth-library-ruby/issues/299