### PR TITLE
feat: Adding support for pluggable auth credentials

### DIFF
--- a/lib/googleauth/external_account.rb
+++ b/lib/googleauth/external_account.rb
@@ -17,6 +17,7 @@ require "uri"
 require "googleauth/credentials_loader"
 require "googleauth/external_account/aws_credentials"
 require "googleauth/external_account/identity_pool_credentials"
+require "googleauth/external_account/pluggable_credentials"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -79,6 +80,9 @@ module Google
           def make_external_account_credentials user_creds
             unless user_creds[:credential_source][:file].nil? && user_creds[:credential_source][:url].nil?
               return Google::Auth::ExternalAccount::IdentityPoolCredentials.new user_creds
+            end
+            unless user_creds[:credential_source][:executable].nil?
+              return Google::Auth::ExternalAccount::PluggableAuthCredentials.new user_creds
             end
             raise INVALID_EXTERNAL_ACCOUNT_TYPE
           end

--- a/lib/googleauth/external_account/external_account_utils.rb
+++ b/lib/googleauth/external_account/external_account_utils.rb
@@ -86,6 +86,17 @@ module Google
             raise "Invalid time value #{time}"
           end
         end
+
+        def service_account_email
+          return nil if @service_account_impersonation_url.nil?
+          start_idx = @service_account_impersonation_url.rindex "/"
+          end_idx = @service_account_impersonation_url.index ":generateAccessToken"
+          if start_idx != -1 && end_indx != -1 && start_idx < end_idx
+            start_idx += 1
+            return @service_account_impersonation_url[start_idx..end_idx]
+          end
+          nil
+        end
       end
     end
   end

--- a/lib/googleauth/external_account/pluggable_credentials.rb
+++ b/lib/googleauth/external_account/pluggable_credentials.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "open3"
 require "time"
 require "googleauth/external_account/base_credentials"
 require "googleauth/external_account/external_account_utils"
@@ -77,7 +78,7 @@ module Google
           env = inject_environment_variables
           output = subprocess_with_timeout env, @credential_source_executable_command,
                                            @credential_source_executable_timeout_millis
-          response = MultiJson.load output, encoding: "utf-8"
+          response = MultiJson.load output, symbolize_keys: true
           parse_subject_token response
         end
 

--- a/lib/googleauth/external_account/pluggable_credentials.rb
+++ b/lib/googleauth/external_account/pluggable_credentials.rb
@@ -1,0 +1,154 @@
+# Copyright 2023 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "time"
+require "googleauth/external_account/base_credentials"
+require "googleauth/external_account/external_account_utils"
+
+module Google
+  # Module Auth provides classes that provide Google-specific authorization used to access Google APIs.
+  module Auth
+    module ExternalAccount
+      # This module handles the retrieval of credentials from Google Cloud by utilizing the any 3PI
+      # provider then exchanging the credentials for a short-lived Google Cloud access token.
+      class PluggableAuthCredentials
+        # constant for pluggable auth enablement in environment variable.
+        INTERACTIVE_MODE_ENV = "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES".freeze
+        EXECUTABLE_SUPPORTED_MAX_VERSION = 1
+        EXECUTABLE_TIMEOUT_MILLIS_DEFAUT = 30 * 1000
+        EXECUTABLE_TIMEOUT_MILLIS_LOWER_BOUND = 5 * 1000
+        EXECUTABLE_TIMEOUT_MILLIS_UPPER_BOUND = 120 * 1000
+        ID_TOKEN_TYPE = ["urn:ietf:params:oauth:token-type:jwt", "urn:ietf:params:oauth:token-type:id_token"].freeze
+
+        include Google::Auth::ExternalAccount::BaseCredentials
+        include Google::Auth::ExternalAccount::ExternalAccountUtils
+        extend CredentialsLoader
+
+        # Will always be nil, but method still gets used.
+        attr_reader :client_id
+
+        # Initialize from options map.
+        #
+        # @param [string] audience
+        # @param [hash{symbol => value}] credential_source
+        #     credential_source is a hash that contains either source file or url.
+        #     credential_source_format is either text or json. To define how we parse the credential response.
+        #
+        def initialize options = {}
+          base_setup options
+
+          @audience = options[:audience]
+          @credential_source = options[:credential_source] || {}
+          @credential_source_executable = @credential_source[:executable]
+          raise "Missing excutable source. An 'executable' must be provided" if @credential_source_executable.nil?
+          @credential_source_executable_command = @credential_source_executable[:command]
+          if @credential_source_executable_command.nil?
+            raise "Missing command field. Executable command must be provided."
+          end
+          @credential_source_executable_timeout_millis = @credential_source_executable[:timeout_millis] ||
+                                                         EXECUTABLE_TIMEOUT_MILLIS_DEFAUT
+          if @credential_source_executable_timeout_millis < EXECUTABLE_TIMEOUT_MILLIS_LOWER_BOUND ||
+             @credential_source_executable_timeout_millis > EXECUTABLE_TIMEOUT_MILLIS_UPPER_BOUND
+            raise "Timeout must be between 5 and 120 seconds."
+          end
+          @credential_source_executable_output_file = @credential_source_executable[:output_file]
+        end
+
+        def retrieve_subject_token!
+          unless ENV[INTERACTIVE_MODE_ENV] == "1"
+            raise "Executables need to be explicitly allowed (set GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES to '1') " \
+                  "to run."
+          end
+          # check output file first
+          subject_token = load_subject_token_from_output_file
+          return subject_token unless subject_token.nil?
+          # environment variable injection
+          env = inject_environment_variables
+          output = subprocess_with_timeout env, @credential_source_executable_command,
+                                           @credential_source_executable_timeout_millis
+          response = MultiJson.load output, encoding: "utf-8"
+          parse_subject_token response
+        end
+
+        private
+
+        def load_subject_token_from_output_file
+          return nil if @credential_source_executable_output_file.nil?
+          return nil unless File.exist? @credential_source_executable_output_file
+          begin
+            content = File.read @credential_source_executable_output_file, encoding: "utf-8"
+            response = MultiJson.laod content, symbolize_keys: true
+          rescue StandardError
+            return nil
+          end
+          begin
+            subject_token = parse_subject_token response
+          rescue StandardError => e
+            return nil if e.message.match(/The token returned by the executable is expired/)
+            subject_token
+          end
+        end
+
+        def parse_subject_token response
+          validate_response_schema response
+          unless response[:success]
+            if response[:code].nil? || response[:message].nil?
+              raise "Error code and message fields are required in the response."
+            end
+            raise "Executable returned unsuccessful response: code: #{response[:code]}, message: #{response[:message]}."
+          end
+          if response[:expiration_time] && response[:expiration_time] < Time.now.to_i
+            raise "The token returned by the executable is expired."
+          end
+          raise "The executable response is missing the token_type field." if response[:token_type].nil?
+          return response[:id_token] if ID_TOKEN_TYPE.include? response[:token_type]
+          return response[:saml_token] if response[:token_type] == "urn:ietf:params:oauth:token-type:saml2"
+          raise "Executable returned unsupported token type."
+        end
+
+        def validate_response_schema response
+          raise "The executable response is missing the version field." if response[:version].nil?
+          if response[:version] > EXECUTABLE_SUPPORTED_MAX_VERSION
+            raise "Executable returned unsupported version #{response[:version]}."
+          end
+          raise "The executable response is missing the success field." if response[:success].nil?
+        end
+
+        def inject_environment_variables
+          env = ENV.to_h
+          env["GOOGLE_EXTERNAL_ACCOUNT_AUDIENCE"] = @audience
+          env["GOOGLE_EXTERNAL_ACCOUNT_TOKEN_TYPE"] = @subject_token_type
+          env["GOOGLE_EXTERNAL_ACCOUNT_INTERACTIVE"] = "0" # only non-interactive mode we support.
+          unless @service_account_impersonation_url.nil?
+            env["GOOGLE_EXTERNAL_ACCOUNT_IMPERSONATED_EMAIL"] = service_account_email
+          end
+          unless @credential_source_executable_output_file.nil?
+            env["GOOGLE_EXTERNAL_ACCOUNT_OUTPUT_FILE"] = @credential_source_executable_output_file
+          end
+          env
+        end
+
+        def subprocess_with_timeout environment_vars, command, timeout_seconds
+          Timeout.timeout timeout_seconds do
+            output, _, status = Open3.capture3 environment_vars, command
+            unless status.success?
+              raise "Executable exited with non-zero return code #{status.exitstatus}. Error: #{output}"
+            end
+            output
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/googleauth/external_account/pluggable_credentials_spec.rb
+++ b/spec/googleauth/external_account/pluggable_credentials_spec.rb
@@ -1,0 +1,200 @@
+# Copyright 2023 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec_dir = File.expand_path File.join(File.dirname(__FILE__))
+$LOAD_PATH.unshift spec_dir
+$LOAD_PATH.uniq!
+
+require 'webmock/rspec'
+require 'googleauth'
+require 'googleauth/external_account/pluggable_credentials'
+
+include Google::Auth::CredentialsLoader
+
+CLIENT_ID = "username"
+CLIENT_SECRET = "password"
+# Base64 encoding of "username:password".
+BASIC_AUTH_ENCODING = "dXNlcm5hbWU6cGFzc3dvcmQ="
+SERVICE_ACCOUNT_EMAIL = "service-1234@service-name.iam.gserviceaccount.com"
+SERVICE_ACCOUNT_IMPERSONATION_URL_BASE = "https://us-east1-iamcredentials.googleapis.com"
+SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = "/v1/projects/-/serviceAccounts/#{SERVICE_ACCOUNT_EMAIL}:generateAccessToken"
+SERVICE_ACCOUNT_IMPERSONATION_URL = SERVICE_ACCOUNT_IMPERSONATION_URL_BASE + SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE
+QUOTA_PROJECT_ID = "QUOTA_PROJECT_ID"
+SCOPES = ["scope1", "scope2"]
+SUBJECT_TOKEN_FIELD_NAME = "access_token"
+
+TOKEN_URL = "https://sts.googleapis.com/v1/token"
+TOKEN_INFO_URL = "https://sts.googleapis.com/v1/introspect"
+SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt"
+AUDIENCE = "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
+DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
+
+describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
+  PluggableAuthCredentials = Google::Auth::ExternalAccount::PluggableAuthCredentials
+  CREDENTIAL_SOURCE_EXECUTABLE_COMMAND = "/fake/external/excutable --arg1=value1 --arg2=value2"
+  CREDENTIAL_SOURCE_EXECUTABLE_OUTPUT_FILE = "fake_output_file"
+  CREDENTIAL_SOURCE_EXECUTABLE = {
+    "command": CREDENTIAL_SOURCE_EXECUTABLE_COMMAND,
+    "timeout_millis": 30000,
+    "interactive_timeout_millis": 300000,
+    "output_file": CREDENTIAL_SOURCE_EXECUTABLE_OUTPUT_FILE,
+  }
+  CREDENTIAL_SOURCE = {"executable": CREDENTIAL_SOURCE_EXECUTABLE}
+  EXECUTABLE_OIDC_TOKEN = "FAKE_ID_TOKEN"
+  EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_ID_TOKEN = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:id_token",
+    "id_token": EXECUTABLE_OIDC_TOKEN,
+    "expiration_time": 9999999999,
+  }
+  EXECUTABLE_SUCCESSFUL_OIDC_NO_EXPIRATION_TIME_RESPONSE_ID_TOKEN = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:id_token",
+    "id_token": EXECUTABLE_OIDC_TOKEN,
+  }
+  EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_JWT = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "id_token": EXECUTABLE_OIDC_TOKEN,
+    "expiration_time": 9999999999,
+  }
+  EXECUTABLE_SUCCESSFUL_OIDC_NO_EXPIRATION_TIME_RESPONSE_JWT = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "id_token": EXECUTABLE_OIDC_TOKEN,
+  }
+  EXECUTABLE_SAML_TOKEN = "FAKE_SAML_RESPONSE"
+  EXECUTABLE_SUCCESSFUL_SAML_RESPONSE = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:saml2",
+    "saml_response": EXECUTABLE_SAML_TOKEN,
+    "expiration_time": 9999999999,
+  }
+  EXECUTABLE_SUCCESSFUL_SAML_NO_EXPIRATION_TIME_RESPONSE = {
+    "version": 1,
+    "success": true,
+    "token_type": "urn:ietf:params:oauth:token-type:saml2",
+    "saml_response": EXECUTABLE_SAML_TOKEN,
+  }
+  EXECUTABLE_FAILED_RESPONSE = {
+    "version": 1,
+    "success": false,
+    "code": "401",
+    "message": "Permission denied. Caller not authorized",
+  }
+  CREDENTIAL_URL = "http://fakeurl.com"
+
+  #####################
+  #
+  #  Test Cases
+  #
+  #####################
+
+  describe "test initialization" do
+    examples = [
+      {
+        name: "from full options",
+        options: {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :token_info_url => nil,
+          :service_account_impersonation_url => nil,
+          :service_account_impersonation_options => {},
+          :client_id => nil,
+          :client_secret => nil,
+          :credential_source => CREDENTIAL_SOURCE,
+          :quota_project_id => nil,
+          :workforce_pool_user_project => nil,
+          :universe_domain => DEFAULT_UNIVERSE_DOMAIN,
+        },
+        expect_result: PluggableAuthCredentials
+      },
+      {
+        :name => "from required options",
+        :options => {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :credential_source => CREDENTIAL_SOURCE,
+        },
+        :expect_result => PluggableAuthCredentials
+      },
+      {
+        :name => "Missing executable source",
+        :options => {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :credential_source => {},
+        },
+        :expect_error => /Missing excutable source. An 'executable' must be provided/
+      },
+      {
+        :name => "Missing executable command",
+        :options => {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :credential_source => { executable: {} },
+        },
+        :expect_error => /Missing command field. Executable command must be provided./
+      },
+      {
+        :name => "Timeout shorter than lower bound",
+        :options => {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :credential_source => {
+            executable: {
+              command: "dummy command",
+              timeout_millis: 2000,
+            }
+          },
+        },
+        :expect_error => /Timeout must be between 5 and 120 seconds./
+      },
+      {
+        :name => "Timeout longer than upper bound",
+        :options => {
+          :audience => AUDIENCE,
+          :subject_token_type => SUBJECT_TOKEN_TYPE,
+          :token_url => TOKEN_URL,
+          :credential_source => {
+            executable: {
+              command: "dummy command",
+              timeout_millis: 120001,
+            }
+          },
+        },
+        :expect_error => /Timeout must be between 5 and 120 seconds./
+      },
+    ]
+    examples.each do |example|
+      it example[:name] do
+        if example[:expect_error].nil?
+          expect(PluggableAuthCredentials.new example[:options]).to be_a(example[:expect_result])
+        else
+          expect{PluggableAuthCredentials.new example[:options]}.to raise_error(example[:expect_error])
+        end
+      end
+    end
+  end
+end

--- a/spec/googleauth/external_account_spec.rb
+++ b/spec/googleauth/external_account_spec.rb
@@ -64,6 +64,28 @@ describe Google::Auth::ExternalAccount::Credentials do
       end
     end
 
+    it 'should be able to make pluggable auth credentials' do
+      f = Tempfile.new('file')
+      begin
+        f.write(MultiJson.dump({
+          type: 'external_account',
+          audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+          subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+          token_url: 'https://sts.googleapis.com/v1/token',
+          credential_source: {
+            executable: {
+              command: 'dummy_command',
+            },
+          },
+        }))
+        f.rewind
+        expect(Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f)).to be_a(Google::Auth::ExternalAccount::PluggableAuthCredentials)
+      ensure
+        f.close
+        f.unlink
+      end
+    end
+
     [:audience, :subject_token_type, :token_url, :credential_source].each do |field|
       it "should raise an error when missing the #{field} field" do
         f = Tempfile.new('missing')


### PR DESCRIPTION
Federated OIDC support for workload/workforce in case of the user cannot using a file or url to fetch subject token, we can allow user to provide an executable that we can run to fetch subject token.