### PR TITLE
chore: Fix rack deprecation warnings.

### DIFF
--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -192,13 +192,13 @@ module Google
       end
 
       def self.extract_callback_state request
-        state = MultiJson.load(request[STATE_PARAM] || "{}")
+        state = MultiJson.load(request.params[STATE_PARAM] || "{}")
         redirect_uri = state[CURRENT_URI_KEY]
         callback_state = {
-          AUTH_CODE_KEY  => request[AUTH_CODE_KEY],
-          ERROR_CODE_KEY => request[ERROR_CODE_KEY],
+          AUTH_CODE_KEY  => request.params[AUTH_CODE_KEY],
+          ERROR_CODE_KEY => request.params[ERROR_CODE_KEY],
           SESSION_ID_KEY => state[SESSION_ID_KEY],
-          SCOPE_KEY      => request[SCOPE_KEY]
+          SCOPE_KEY      => request.params[SCOPE_KEY]
         }
         [callback_state, redirect_uri]
       end


### PR DESCRIPTION
Replace `request[]` calls with `request.params[]`. To fix the deprecation warnings in:

Rack 3.x: https://github.com/rack/rack/blob/3-0-stable/lib/rack/request.rb#L608
Rack 2.x: https://github.com/rack/rack/blob/2-2-stable/lib/rack/request.rb#L531