### PR TITLE
feat: Use google-cloud-env for more robust Metadata Service access

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -6,14 +6,13 @@ branchProtectionRules:
   isAdminEnforced: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'CI (macos-latest, 3.0, test , spec)'
-    - 'CI (ubuntu-20.04, 2.6, test , spec)'
+    - 'CI (macos-latest, 3.2, test , spec)'
     - 'CI (ubuntu-20.04, 2.7, test , spec)'
     - 'CI (ubuntu-20.04, 3.0, test , spec)'
     - 'CI (ubuntu-20.04, 3.1, test , spec)'
-    - 'CI (ubuntu-22.04, 3.1, test , spec)'
-    - 'CI (ubuntu-latest, 3.0, rubocop , integration , build , yardoc , linkinator)'
-    - 'CI (windows-latest, 3.0, test , spec)'
+    - 'CI (ubuntu-22.04, 3.2, test , spec)'
+    - 'CI (ubuntu-latest, 3.2, rubocop , integration , build , yardoc , linkinator)'
+    - 'CI (windows-latest, 3.2, test , spec)'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            ruby: "2.6"
-            task: test , spec
-          - os: ubuntu-20.04
             ruby: "2.7"
             task: test , spec
           - os: ubuntu-20.04
@@ -26,16 +23,16 @@ jobs:
             ruby: "3.1"
             task: test , spec  
           - os: ubuntu-22.04
-            ruby: "3.1"
+            ruby: "3.2"
             task: test , spec
           - os: macos-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: test , spec
           - os: windows-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: test , spec
           - os: ubuntu-latest
-            ruby: "3.0"
+            ruby: "3.2"
             task: rubocop , integration , build , yardoc , linkinator
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem "fakefs", ">= 1.0", "< 3"
 gem "fakeredis", "~> 0.5"
 gem "gems", "~> 1.2"
-gem "google-style", "~> 1.26.1"
+gem "google-style", "~> 1.27.0"
 gem "logging", "~> 2.0"
 gem "minitest", "~> 5.14"
 gem "minitest-focus", "~> 1.1"

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.platform = Gem::Platform::RUBY
-  gem.required_ruby_version = ">= 2.6"
+  gem.required_ruby_version = ">= 2.7"
 
-  gem.add_dependency "faraday", ">= 0.17.3", "< 3.a"
+  gem.add_dependency "faraday", ">= 1.0", "< 3.a"
+  gem.add_dependency "google-cloud-env", "~> 2.0", ">= 2.0.1"
   gem.add_dependency "jwt", ">= 1.4", "< 3.0"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"

--- a/lib/googleauth/application_default.rb
+++ b/lib/googleauth/application_default.rb
@@ -55,11 +55,7 @@ module Google
               DefaultCredentials.from_well_known_path(scope, options) ||
               DefaultCredentials.from_system_default_path(scope, options)
       return creds unless creds.nil?
-      unless GCECredentials.on_gce? options
-        # Clear cache of the result of GCECredentials.on_gce?
-        GCECredentials.reset_cache
-        raise NOT_FOUND_ERROR
-      end
+      raise NOT_FOUND_ERROR unless GCECredentials.on_gce? options
       GCECredentials.new options.merge(scope: scope)
     end
   end

--- a/lib/googleauth/external_account/base_credentials.rb
+++ b/lib/googleauth/external_account/base_credentials.rb
@@ -85,8 +85,7 @@ module Google
         #     true if the credentials represent a workforce pool.
         #     false if they represent a workload.
         def is_workforce_pool?
-          pattern = "//iam\.googleapis\.com/locations/[^/]+/workforcePools/"
-          /#{pattern}/.match?(@audience || "")
+          %r{/iam\.googleapis\.com/locations/[^/]+/workforcePools/}.match?(@audience || "")
         end
 
         private

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -150,6 +150,7 @@ shared_examples "apply/apply! are OK" do
         want = { :foo => "bar", auth_key => "Bearer #{t}" }
         expect(got).to eq(want)
         @client.expires_at -= 3601 # default is to expire in 1hr
+        Google::Cloud.env.compute_metadata.cache.expire_all!
       end
     end
   end


### PR DESCRIPTION
This is a prerequisite for proper universe_domain support. It removes the code that makes direct calls to the Metadata Server (to determine GCE residence and to fetch Metadata-provided access tokens), and instead delegates to the more robust code in the google-cloud-env 2.0 gem.

Also drops support for Ruby 2.6 since google-cloud-env 2.0 also drops Ruby 2.6.

Also closes #444.