### PR TITLE
fix: Get the project_id from gcloud

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -37,7 +37,7 @@ module Google
       AWS_SESSION_TOKEN_VAR     = "AWS_SESSION_TOKEN".freeze
       GCLOUD_POSIX_COMMAND      = "gcloud".freeze
       GCLOUD_WINDOWS_COMMAND    = "gcloud.cmd".freeze
-      GCLOUD_CONFIG_COMMAND     = "config config-helper --format json --verbosity none".freeze
+      GCLOUD_CONFIG_COMMAND     = "config config-helper --format json --verbosity none --quiet".freeze
 
       CREDENTIALS_FILE_NAME = "application_default_credentials.json".freeze
       NOT_FOUND_ERROR = "Unable to read the credential file specified by #{ENV_VAR}".freeze
@@ -146,7 +146,7 @@ module Google
       def load_gcloud_project_id
         gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
         gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
-        gcloud_json = IO.popen("#{gcloud} #{GCLOUD_CONFIG_COMMAND}", in: :close, err: :close, &:read)
+        gcloud_json = IO.popen("#{gcloud} #{GCLOUD_CONFIG_COMMAND}", err: :close, &:read)
         config = MultiJson.load gcloud_json
         config["configuration"]["properties"]["core"]["project"]
       rescue StandardError


### PR DESCRIPTION
I think the spirit of https://github.com/googleapis/google-auth-library-ruby/commit/990250345d6af31de1066c08c0b3b42692ae263c was to prevent `gcloud` from popping out of the console and hanging. Unfortunately, this will always close the subprocess and return an empty string.

This causes downstream issues, for example when initializing a new BigQuery client [0] that relies on the credential to carry the `project_id`.

Adding `--quiet` will disable interactive prompts and either attempt to use defaults or error.


0. https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-bigquery/lib/google/cloud/bigquery.rb