### PR TITLE
suppress annoying warning

### DIFF
--- a/lib/googleauth/helpers/connection.rb
+++ b/lib/googleauth/helpers/connection.rb
@@ -24,7 +24,7 @@ module Google
       module Connection
         module_function
 
-        attr_accessor :default_connection
+        silence_warnings { attr_accessor :default_connection }
 
         def connection
           @default_connection || Faraday.default_connection


### PR DESCRIPTION
This solves https://github.com/googleapis/google-auth-library-ruby/issues/424 for now. The issue has been open for over a year, so I'm guessing nobody has the bandwidth to fix it. This will keep it from spamming log files in the meantime