### PR TITLE
refactor: Use NoMethodError for base classes

### DIFF
--- a/lib/googleauth/base_client.rb
+++ b/lib/googleauth/base_client.rb
@@ -63,17 +63,17 @@ module Google
       end
 
       def expires_within?
-        raise NotImplementedError
+        raise NoMethodError, "expires_within? not implemented"
       end
 
       private
 
       def token_type
-        raise NotImplementedError
+        raise NoMethodError, "token_type not implemented"
       end
 
       def fetch_access_token!
-        raise NotImplementedError
+        raise NoMethodError, "fetch_access_token! not implemented"
       end
     end
   end

--- a/lib/googleauth/external_account/base_credentials.rb
+++ b/lib/googleauth/external_account/base_credentials.rb
@@ -76,7 +76,7 @@ module Google
         #     The retrieved subject token.
         #
         def retrieve_subject_token!
-          raise NotImplementedError
+          raise NoMethodError, "retrieve_subject_token! not implemented"
         end
 
         # Returns whether the credentials represent a workforce pool (True) or

--- a/lib/googleauth/token_store.rb
+++ b/lib/googleauth/token_store.rb
@@ -29,7 +29,7 @@ module Google
       # @return [String]
       #  The loaded token data.
       def load _id
-        raise "Not implemented"
+        raise NoMethodError, "load not implemented"
       end
 
       # Put the token data into storage for the given ID.
@@ -39,7 +39,7 @@ module Google
       # @param [String] token
       #  The token data to store.
       def store _id, _token
-        raise "Not implemented"
+        raise NoMethodError, "store not implemented"
       end
 
       # Remove the token data from storage for the given ID.
@@ -47,7 +47,7 @@ module Google
       # @param [String] id
       #  ID of the token data to delete
       def delete _id
-        raise "Not implemented"
+        raise NoMethodError, "delete not implemented"
       end
     end
   end


### PR DESCRIPTION
It is not advisable to raise  NotImplementedError for errors that are not platform errors, such as fsync or fork.
Replace with NoMethodError, which inherits from StandardError.