### PR TITLE
fix: Fixed parsing of expiration timestamp from ID tokens

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "base64"
-require "json"
 require "google-cloud-env"
 require "googleauth/signet"
 
@@ -148,12 +146,9 @@ module Google
 
       def parse_encoded_token body
         hash = { token_type.to_s => body }
-        if token_type == :id_token && body =~ /^[\w=-]+\.([\w=-]+)\.[\w=-]+$/
-          base64 = Base64.urlsafe_decode64 Regexp.last_match[1]
-          json = JSON.parse base64 rescue nil
-          if json.respond_to?(:key?) && json.key?("exp")
-            hash["expires_at"] = Time.at json["exp"].to_i
-          end
+        if token_type == :id_token
+          expires_at = expires_at_from_id_token body
+          hash["expires_at"] = expires_at if expires_at
         end
         hash
       end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "base64"
+require "json"
 require "signet/oauth_2/client"
 require "googleauth/base_client"
 
@@ -29,6 +31,8 @@ module Signet
 
       def update_token! options = {}
         options = deep_hash_normalize options
+        id_token_expires_at = expires_at_from_id_token options[:id_token]
+        options[:expires_at] = id_token_expires_at if id_token_expires_at
         update_token_signet_base options
         self.universe_domain = options[:universe_domain] if options.key? :universe_domain
         self
@@ -88,6 +92,17 @@ module Signet
             raise Signet::AuthorizationError, msg
           end
         end
+      end
+
+      private
+
+      def expires_at_from_id_token id_token
+        match = /^[\w=-]+\.([\w=-]+)\.[\w=-]+$/.match id_token.to_s
+        return unless match
+        base64 = Base64.urlsafe_decode64 match[1]
+        json = JSON.parse base64 rescue nil
+        return unless json.respond_to?(:key?) && json.key?("exp")
+        Time.at json["exp"].to_i
       end
     end
   end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -99,10 +99,12 @@ module Signet
       def expires_at_from_id_token id_token
         match = /^[\w=-]+\.([\w=-]+)\.[\w=-]+$/.match id_token.to_s
         return unless match
-        base64 = Base64.urlsafe_decode64 match[1]
-        json = JSON.parse base64 rescue nil
-        return unless json.respond_to?(:key?) && json.key?("exp")
+        json = JSON.parse Base64.urlsafe_decode64 match[1]
+        return unless json.key? "exp"
         Time.at json["exp"].to_i
+      rescue StandardError
+        # Shouldn't happen unless we get a garbled ID token
+        nil
       end
     end
   end


### PR DESCRIPTION
Looks like this was never implemented, with the result that ID token credential objects stopped working when the token expired.