### PR TITLE
fix: Temporarily disable universe domain query from GCE metadata server

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,14 @@ AllCops:
     - "integration/**/*"
     - "spec/**/*"
     - "test/**/*"
-Metrics/ClassLength:
-  Max: 200
-Metrics/ModuleLength:
-  Max: 110
 Metrics/BlockLength:
   Exclude:
     - "googleauth.gemspec"
+Metrics/ClassLength:
+  Max: 200
+Metrics/CyclomaticComplexity:
+  Max: 15
+Metrics/ModuleLength:
+  Max: 200
+Metrics/PerceivedComplexity:
+  Max: 15

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -299,6 +299,12 @@ module Google
       #
       attr_reader :quota_project_id
 
+      # @private Temporary; remove when universe domain metadata endpoint is stable (see b/349488459).
+      def disable_universe_domain_check
+        return false unless @client.respond_to? :disable_universe_domain_check
+        @client.disable_universe_domain_check
+      end
+
       # @private Delegate client methods to the client object.
       extend Forwardable
 


### PR DESCRIPTION
This is Ruby's response to internal issue b/349488459. In this PR, we add a (temporary, optional) attribute (`disable_universe_domain_check`) to credential objects that signals the credential may incorrectly claim googleapis as its universe domain. This will be used for GCECredentials temporarily; when set (which for now it will be), GCECredentials will not query the metadata server for universe domain but will instead hard-code `googleapis.com`. Then, the client libraries (in gapic-common, via https://github.com/googleapis/gapic-generator-ruby/pull/1119) will check for the `disable_universe_domain_check` attribute, and if present and set, will not perform the universe domain consistency check. This will effectively stop universe domain MDS calls and checks for GCE credentials while leaving them active for all other credential types. It will also not break existing normal (googleapis) users because those credential objects will continue to report `googleapis.com` as the universe. Early testers of non-googleapis universes will simply have to update both the googleauth and gapic-common gems.