### PR TITLE
Return the hash with the token

### DIFF
--- a/lib/googleauth/base_client.rb
+++ b/lib/googleauth/base_client.rb
@@ -38,7 +38,7 @@ module Google
           Google::Logging::Message.from message: "Sending auth token. (sha256:#{hash})"
         end
 
-        a_hash
+        a_hash[AUTH_METADATA_KEY]
       end
 
       # Returns a clone of a_hash updated with the authentication token


### PR DESCRIPTION
Related to this issue https://github.com/googleapis/google-auth-library-ruby/issues/505