### PR TITLE
fix: GCECredentials lazily fetches from the metadata server to ensure a universe domain is known

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -93,6 +93,19 @@ module Google
         super options
       end
 
+      # @private
+      # Overrides universe_domain getter to fetch lazily if it hasn't been
+      # fetched yet. This is necessary specifically for Compute Engine because
+      # the universe comes from the metadata service, and isn't known
+      # immediately on credential construction. All other credential types read
+      # the universe from their json key or other immediate input.
+      def universe_domain
+        value = super
+        return value unless value.nil?
+        fetch_access_token!
+        super
+      end
+
       # Overrides the super class method to change how access tokens are
       # fetched.
       def fetch_access_token _options = {}

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -97,6 +97,11 @@ describe Google::Auth::GCECredentials do
         expect(@client.universe_domain).to eq("googleapis.com")
       end
 
+      it "sets the universe without explicit fetch_access_token" do
+        make_auth_stubs access_token: "1/abcde"
+        expect(@client.universe_domain).to eq("googleapis.com")
+      end
+
       it "returns a consistent expiry using cached data" do
         make_auth_stubs access_token: "1/abcde"
         @client.fetch_access_token!
@@ -121,6 +126,11 @@ describe Google::Auth::GCECredentials do
         expect(@client.universe_domain).to eq("googleapis.com")
       end
 
+      it "sets the universe without explicit fetch_access_token" do
+        make_auth_stubs access_token: "1/abcde"
+        expect(@client.universe_domain).to eq("googleapis.com")
+      end
+
       it "returns a consistent expiry using cached data" do
         make_auth_stubs access_token: "1/abcde"
         @client.fetch_access_token!
@@ -141,6 +151,11 @@ describe Google::Auth::GCECredentials do
       it "sets the universe" do
         make_auth_stubs access_token: "1/abcde"
         @client.fetch_access_token!
+        expect(@client.universe_domain).to eq("myuniverse.com")
+      end
+
+      it "sets the universe without explicit fetch_access_token" do
+        make_auth_stubs access_token: "1/abcde"
         expect(@client.universe_domain).to eq("myuniverse.com")
       end
 


### PR DESCRIPTION
As part of the logging work, to tamp down on the possible glut of logs on startup in high-traffic environments, we stopped eagerly fetching tokens from the client library credentials object. This was intended not to make any functional difference, because credential objects generally fetch their own tokens just-in-time when requested.

However, #508 revealed one case we missed: GCECredentials do not have a `universe_domain` set until the token is fetched, since the universe domain comes from the metadata service. Thus, client libraries would fail to initialize with a universe domain mismatch error. This happens *only*:

* for GCECredentials, as all other credential types get their universe domain from the input (e.g. json key file), **and**
* if the `gapic-common` gem is older than 0.23.0, because that version temporarily disabled universe domain checking for compute engine for unrelated reasons

Because the intent is for a future version of `gapic-common` to re-enable universe domain checking, and because some customers have not or cannot update `gapic-common`, we're going to work around this by causing GCECredentials to fetch its token just-in-time if its universe_domain is queried.

Fixes #508 
