### PR TITLE
fix: Signet client subclasses no longer make the `update!` method private

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -154,8 +154,6 @@ module Google
         end
       end
 
-      private
-
       # Destructively updates these credentials.
       #
       # This method is called by `Signet::OAuth2::Client`'s constructor
@@ -176,6 +174,8 @@ module Google
 
         self
       end
+
+      private
 
       def log_fetch_query
         if token_type == :id_token

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -136,8 +136,6 @@ module Google
         super && !enable_self_signed_jwt?
       end
 
-      private
-
       # Destructively updates these credentials
       #
       # This method is called by `Signet::OAuth2::Client`'s constructor
@@ -163,6 +161,8 @@ module Google
 
         self
       end
+
+      private
 
       def apply_self_signed_jwt! a_hash
         # Use the ServiceAccountJwtHeaderCredentials using the same cred values

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -135,8 +135,6 @@ module Google
         missing_scope.empty?
       end
 
-      private
-
       # Destructively updates these credentials
       #
       # This method is called by `Signet::OAuth2::Client`'s constructor


### PR DESCRIPTION
The `update!` method is public in `Signet::OAuth2::Client`. #499 made it private in some subclasses, causing a regression for certain workflows. This makes the method public again.

Fixes #515 