### PR TITLE
fix: `attribute accessor as module_function` warning

### DIFF
--- a/lib/googleauth/helpers/connection.rb
+++ b/lib/googleauth/helpers/connection.rb
@@ -28,7 +28,7 @@ module Google
           @default_connection
         end
 
-        def default_connection=(conn)
+        def default_connection= conn
           @default_connection = conn
         end
 

--- a/lib/googleauth/helpers/connection.rb
+++ b/lib/googleauth/helpers/connection.rb
@@ -22,7 +22,7 @@ module Google
     module Helpers
       # Connection provides a Faraday connection for use with Google::Auth.
       module Connection
-        module_function
+        private
 
         attr_accessor :default_connection
 

--- a/lib/googleauth/helpers/connection.rb
+++ b/lib/googleauth/helpers/connection.rb
@@ -22,9 +22,15 @@ module Google
     module Helpers
       # Connection provides a Faraday connection for use with Google::Auth.
       module Connection
-        private
+        module_function
 
-        attr_accessor :default_connection
+        def default_connection
+          @default_connection
+        end
+
+        def default_connection=(conn)
+          @default_connection = conn
+        end
 
         def connection
           @default_connection || Faraday.default_connection


### PR DESCRIPTION
```
googleauth-1.13.1/lib/googleauth/helpers/connection.rb:27: warning: attribute accessor as module_function
```

This code was introduced in 1354b076a159d223b737e5b1f27dde0463eb5292.

`module_function` cause the next methods to be defined as both class methods and private instance methods, but the class method part is never used, hence directly declaring them as private is simpler and avoid the warning.