### PR TITLE
feat: add BearerToken credentials

### DIFF
--- a/lib/googleauth.rb
+++ b/lib/googleauth.rb
@@ -14,6 +14,7 @@
 
 require "googleauth/application_default"
 require "googleauth/api_key"
+require "googleauth/bearer_token"
 require "googleauth/client_id"
 require "googleauth/credentials"
 require "googleauth/default_credentials"

--- a/lib/googleauth/api_key.rb
+++ b/lib/googleauth/api_key.rb
@@ -113,14 +113,13 @@ module Google
         )
       end
 
-
       # Updates the procided hash with the API Key header.
       #
       # The `apply!` method modifies the provided hash in place, adding the
       # `x-goog-api-key` header with the API Key value.
       #
       # The API Key is hashed before being logged for security purposes.
-      # 
+      #
       # NB: this method typically would be called through `updater_proc`.
       # Some older clients call it directly though, so it has to be public.
       #

--- a/lib/googleauth/api_key.rb
+++ b/lib/googleauth/api_key.rb
@@ -113,7 +113,7 @@ module Google
         )
       end
 
-      # Updates the procided hash with the API Key header.
+      # Updates the provided hash with the API Key header.
       #
       # The `apply!` method modifies the provided hash in place, adding the
       # `x-goog-api-key` header with the API Key value.

--- a/lib/googleauth/api_key.rb
+++ b/lib/googleauth/api_key.rb
@@ -113,6 +113,33 @@ module Google
         )
       end
 
+
+      # Updates the procided hash with the API Key header.
+      #
+      # The `apply!` method modifies the provided hash in place, adding the
+      # `x-goog-api-key` header with the API Key value.
+      #
+      # The API Key is hashed before being logged for security purposes.
+      # 
+      # NB: this method typically would be called through `updater_proc`.
+      # Some older clients call it directly though, so it has to be public.
+      #
+      # @param [Hash] a_hash The hash to which the API Key header should be added.
+      #   This is typically a hash representing the request headers.  This hash
+      #   will be modified in place.
+      # @param [Hash] _opts  Additional options (currently not used).  Included
+      #   for consistency with the `BaseClient` interface.
+      # @return [Hash] The modified hash (the same hash passed as the `a_hash`
+      #   argument).
+      def apply! a_hash, _opts = {}
+        a_hash[API_KEY_HEADER] = @api_key
+        logger&.debug do
+          hash = Digest::SHA256.hexdigest @api_key
+          Google::Logging::Message.from message: "Sending API key auth token. (sha256:#{hash})"
+        end
+        a_hash
+      end
+
       protected
 
       # The token type should be :api_key
@@ -123,15 +150,6 @@ module Google
       # We don't need to fetch access tokens for API key auth
       def fetch_access_token! _options = {}
         nil
-      end
-
-      def apply! a_hash, _opts = {}
-        a_hash[API_KEY_HEADER] = @api_key
-        logger&.debug do
-          hash = Digest::SHA256.hexdigest @api_key
-          Google::Logging::Message.from message: "Sending API key auth token. (sha256:#{hash})"
-        end
-        a_hash
       end
     end
   end

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -32,6 +32,11 @@ module Google
     # This means that tasks like tracking the lifetime of and
     # refreshing the token are outside the scope of this class.
     #
+    # There is no JSON representation for this type of credentials.
+    # If the end-user has credentials in JSON format they should typically
+    # use the corresponding credentials type, e.g. ServiceAccountCredentials
+    # with the service account JSON.
+    #
     class BearerTokenCredentials
       include Google::Auth::BaseClient
 
@@ -138,7 +143,10 @@ module Google
       end
 
       def apply! a_hash, _opts = {}
-        a_hash[AUTHORIZATION_HEADER_NAME] = "Bearer #{@token}" # Use token_type_string method
+      require 'pry'
+      binding.pry
+
+        a_hash[AUTHORIZATION_HEADER_NAME] = "Bearer #{@token}"
         logger&.debug do
           hash = Digest::SHA256.hexdigest @token
           Google::Logging::Message.from message: "Sending #{token_type_string} auth token. (sha256:#{hash})"

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -48,6 +48,11 @@ module Google
 
       # @return [String] The token to be sent as a part of Bearer claim
       attr_reader :token
+      # The following aliasing is needed for BaseClient since it sends :token_type
+      alias :access_token :token
+      alias :jwt :token
+      alias :id_token :token
+      alias :bearer_token :token
 
       # @return [Time, nil] The token expiry time provided by the end-user.
       attr_reader :expiry
@@ -135,20 +140,11 @@ module Google
         )
       end
 
-      def apply! a_hash, _opts = {}
-        a_hash[AUTH_METADATA_KEY] = "Bearer #{token}"
-        logger&.debug do
-          hash = Digest::SHA256.hexdigest @token
-          Google::Logging::Message.from message: "Sending #{token_type_string} auth token. (sha256:#{hash})"
-        end
-        a_hash
-      end
-
       protected
 
       # We don't need to fetch access tokens for bearer token auth
       def fetch_access_token! _options = {}
-        nil
+        @token
       end
 
       private

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -1,0 +1,134 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth/base_client"
+
+module Google
+  module Auth
+    ##
+    # Implementation of Bearer Token authentication.
+    #
+    # Bearer tokens are strings representing an authorization grant.  They
+    # are typically used with OAuth 2.0.
+    #
+    class BearerTokenCredentials
+      include Google::Auth::BaseClient
+
+      # Authorization header key
+      BEARER_TOKEN_HEADER = "Authorization".freeze
+
+      # Allowed token types
+      ALLOWED_TOKEN_TYPES = [:access_token, :jwt, :id_token, :bearer_token].freeze
+
+      # @private The bearer token
+      attr_reader :bearer_token
+
+      # @private The token expiry time (Time object or nil)
+      attr_reader :expiry
+
+       # @private The token type
+      attr_reader :token_type
+
+      # @private The universe domain
+      attr_accessor :universe_domain
+
+      # Initialize the BearerTokenCredentials.
+      #
+      # @param [Hash] options The credentials options
+      # @option options [String] :bearer_token The bearer token to use.
+      # @option options [Time, Numeric] :expiry The token expiry time. Can be a Time
+      #   object or a number of seconds since epoch.
+      # @option options [Symbol] :token_type The token type. Allowed values are
+      #   :access_token, :jwt, :id_token, and :bearer_token. Defaults to :bearer_token.
+      # @option options [String] :universe_domain The universe domain (defaults to googleapis.com)
+      def initialize options = {}
+        raise ArgumentError, "Bearer token must be provided" if options[:bearer_token].nil? || options[:bearer_token].empty?
+        @bearer_token = options[:bearer_token]
+        @expiry = if options[:expiry].is_a?(Time)
+                    options[:expiry]
+                  elsif options[:expiry].is_a?(Numeric)
+                    Time.at(options[:expiry])
+                  end
+
+        @token_type = options[:token_type] || :bearer_token
+        unless ALLOWED_TOKEN_TYPES.include?(@token_type)
+          raise ArgumentError, "Invalid token type: #{@token_type}. Allowed values are #{ALLOWED_TOKEN_TYPES.inspect}"
+        end
+
+        @universe_domain = options[:universe_domain] || "googleapis.com"
+      end
+
+      # Determines if the credentials object has expired.
+      #
+      # @param [Numeric] seconds The optional timeout in seconds.
+      # @return [Boolean] True if the token has expired, false otherwise.
+      def expires_within? seconds = 0
+        return false if @expiry.nil?
+        Time.now + seconds >= @expiry
+      end
+
+      # Creates a duplicate of these credentials.
+      #
+      # @param [Hash] options Additional options for configuring the credentials
+      # @return [Google::Auth::BearerTokenCredentials]
+      def duplicate options = {}
+        self.class.new(
+          bearer_token: options[:bearer_token] || @bearer_token,
+          expiry: options[:expiry] || @expiry,
+          universe_domain: options[:universe_domain] || @universe_domain
+        )
+      end
+
+      protected
+
+      # The token type should be :bearer
+      def token_type
+        :bearer
+      end
+
+      # We don't need to fetch access tokens for bearer token auth
+      def fetch_access_token! _options = {}
+        nil
+      end
+
+      class << self
+        # Create the BearerTokenCredentials.
+        #
+        # @param [Hash] options The credentials options
+        # @option options [String] :bearer_token The bearer token to use.
+        # @option options [Time, Numeric] :expiry The token expiry time. Can be a Time
+        #   object or a number of seconds since epoch.
+        # @option options [String] :universe_domain The universe domain (defaults to googleapis.com)
+        # @return [Google::Auth::BearerTokenCredentials]
+        def make_creds options = {}
+          new options
+        end
+      end
+
+      def apply! a_hash, _opts = {}
+        a_hash[BEARER_TOKEN_HEADER] = "#{token_type_string} #{@bearer_token}" # Use token_type_string method
+        logger&.debug do
+          Google::Logging::Message.from message: "Sending #{token_type_string} auth token. (truncated)" # Consider logging hash instead
+        end
+        a_hash
+      end
+
+      private
+
+      def token_type_string
+        @token_type.to_s.split('_').map(&:capitalize).join(' ') #Nicely format token type for the header
+      end
+    end
+  end
+end

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -49,10 +49,10 @@ module Google
       # @return [String] The token to be sent as a part of Bearer claim
       attr_reader :token
       # The following aliasing is needed for BaseClient since it sends :token_type
-      alias :access_token :token
-      alias :jwt :token
-      alias :id_token :token
-      alias :bearer_token :token
+      alias access_token token
+      alias jwt token
+      alias id_token token
+      alias bearer_token token
 
       # @return [Time, nil] The token expiry time provided by the end-user.
       attr_reader :expiry

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -43,23 +43,13 @@ module Google
       # @private Authorization header name
       AUTH_METADATA_KEY = Google::Auth::BaseClient::AUTH_METADATA_KEY
 
-      # @private Allowed token types
-      ALLOWED_TOKEN_TYPES = [:access_token, :jwt, :id_token, :bearer_token].freeze
-
       # @return [String] The token to be sent as a part of Bearer claim
       attr_reader :token
       # The following aliasing is needed for BaseClient since it sends :token_type
-      alias access_token token
-      alias jwt token
-      alias id_token token
       alias bearer_token token
 
       # @return [Time, nil] The token expiration time provided by the end-user.
       attr_reader :expires_at
-
-      # @return [Symbol] The token type. Allowed values are
-      #   :access_token, :jwt, :id_token, and :bearer_token.
-      attr_reader :token_type
 
       # @return [String] The universe domain of the universe
       #   this token is for
@@ -73,8 +63,6 @@ module Google
         # @option options [Time, Numeric, nil] :expires_at The token expiration time provided by the end-user.
         #   Optional, for the end-user's convenience. Can be a Time object, a number of seconds since epoch.
         #   If `expires_at` is `nil`, it is treated as "token never expires".
-        # @option options [Symbol] :token_type The token type. Allowed values are
-        #   :access_token, :jwt, :id_token, and :bearer_token. Defaults to :bearer_token.
         # @option options [String] :universe_domain The universe domain of the universe
         #   this token is for (defaults to googleapis.com)
         # @return [Google::Auth::BearerTokenCredentials]
@@ -90,8 +78,6 @@ module Google
       # @option options [Time, Numeric, nil] :expires_at The token expiration time provided by the end-user.
       #   Optional, for the end-user's convenience. Can be a Time object, a number of seconds since epoch.
       #   If `expires_at` is `nil`, it is treated as "token never expires".
-      # @option options [Symbol] :token_type The token type. Allowed values are
-      #   :access_token, :jwt, :id_token, and :bearer_token. Defaults to :bearer_token.
       # @option options [String] :universe_domain The universe domain of the universe
       #   this token is for (defaults to googleapis.com)
       def initialize options = {}
@@ -103,11 +89,6 @@ module Google
                       when Numeric
                         Time.at options[:expires_at]
                       end
-
-        @token_type = options[:token_type] || :bearer_token
-        unless ALLOWED_TOKEN_TYPES.include? @token_type
-          raise ArgumentError, "Invalid token type: #{@token_type}. Allowed values are #{ALLOWED_TOKEN_TYPES.inspect}"
-        end
 
         @universe_domain = options[:universe_domain] || "googleapis.com"
       end
@@ -128,15 +109,12 @@ module Google
       # @option options [String] :token The bearer token to use.
       # @option options [Time, Numeric] :expires_at The token expiration time. Can be a Time
       #   object or a number of seconds since epoch.
-      # @option options [Symbol] :token_type The token type. Allowed values are
-      #   :access_token, :jwt, :id_token, and :bearer_token. Defaults to :bearer_token.
       # @option options [String] :universe_domain The universe domain (defaults to googleapis.com)
       # @return [Google::Auth::BearerTokenCredentials]
       def duplicate options = {}
         self.class.new(
           token: options[:token] || @token,
           expires_at: options[:expires_at] || @expires_at,
-          token_type: options[:token_type] || @token_type,
           universe_domain: options[:universe_domain] || @universe_domain
         )
       end
@@ -162,8 +140,8 @@ module Google
 
       private
 
-      def token_type_string
-        @token_type.to_s.split("_").map(&:capitalize).join(" ") # Nicely format token type for the header
+      def token_type
+        :bearer_token
       end
     end
   end

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -41,7 +41,7 @@ module Google
       include Google::Auth::BaseClient
 
       # @private Authorization header name
-      AUTHORIZATION_HEADER_NAME = "Authorization".freeze
+      AUTH_METADATA_KEY = Google::Auth::BaseClient::AUTH_METADATA_KEY
 
       # @private Allowed token types
       ALLOWED_TOKEN_TYPES = [:access_token, :jwt, :id_token, :bearer_token].freeze
@@ -135,23 +135,20 @@ module Google
         )
       end
 
-      protected
-
-      # We don't need to fetch access tokens for bearer token auth
-      def fetch_access_token! _options = {}
-        nil
-      end
-
       def apply! a_hash, _opts = {}
-      require 'pry'
-      binding.pry
-
-        a_hash[AUTHORIZATION_HEADER_NAME] = "Bearer #{@token}"
+        a_hash[AUTH_METADATA_KEY] = "Bearer #{token}"
         logger&.debug do
           hash = Digest::SHA256.hexdigest @token
           Google::Logging::Message.from message: "Sending #{token_type_string} auth token. (sha256:#{hash})"
         end
         a_hash
+      end
+
+      protected
+
+      # We don't need to fetch access tokens for bearer token auth
+      def fetch_access_token! _options = {}
+        nil
       end
 
       private

--- a/test/bearer_token_test.rb
+++ b/test/bearer_token_test.rb
@@ -1,0 +1,156 @@
+  # Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "googleauth/bearer_token"
+require "logger"
+require "digest"
+
+describe Google::Auth::BearerTokenCredentials do
+  let(:token) { "test-bearer-token-12345" }
+  let(:example_universe_domain) { "example.com" }
+  let(:expiry) { Time.now + 3600 } # 1 hour from now
+
+  describe "#initialize" do
+    it "creates with token and proper defaults" do
+      creds = Google::Auth::BearerTokenCredentials.new token: token
+      _(creds.token).must_equal token
+      _(creds.token_type).must_equal :bearer_token
+      _(creds.universe_domain).must_equal "googleapis.com"
+    end
+
+    it "creates with custom universe domain" do
+      creds = Google::Auth::BearerTokenCredentials.new(
+        token: token,
+        universe_domain: example_universe_domain
+      )
+      _(creds.universe_domain).must_equal example_universe_domain
+    end
+
+    it "creates with expiry as Time object" do
+      creds = Google::Auth::BearerTokenCredentials.new(token: token, expiry: expiry)
+      _(creds.expiry).must_equal expiry
+    end
+
+    it "creates with expiry as Numeric timestamp" do
+      expiry_seconds = expiry.to_i
+      creds = Google::Auth::BearerTokenCredentials.new(token: token, expiry: expiry_seconds)
+      _(creds.expiry).must_equal Time.at(expiry_seconds)
+    end
+
+    it "creates with custom token type" do
+      creds = Google::Auth::BearerTokenCredentials.new(token: token, token_type: :access_token)
+      _(creds.token_type).must_equal :access_token
+    end
+
+    it "raises if bearer token is missing" do
+      expect do
+        Google::Auth::BearerTokenCredentials.new
+      end.must_raise ArgumentError
+    end
+
+     it "raises if bearer token is empty" do
+      expect do
+        Google::Auth::BearerTokenCredentials.new(token: "")
+      end.must_raise ArgumentError
+    end
+
+    it "raises if invalid token type is provided" do
+      expect do
+        Google::Auth::BearerTokenCredentials.new(token: token, token_type: :invalid)
+      end.must_raise ArgumentError
+    end
+  end
+
+  describe "#apply!" do
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token }
+
+    it "adds Authorization token header to hash" do
+      md = { foo: "bar" }
+      want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTHORIZATION_HEADER_NAME => "Bearer #{token}" }
+      md = creds.apply md
+      _(md).must_equal want
+    end
+
+    it "Token type does not influence the header value" do
+        creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
+        md = { foo: "bar" }
+        want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTHORIZATION_HEADER_NAME => "Bearer #{token}" }
+        md = creds.apply md
+        _(md).must_equal want
+    end
+
+    it "logs (hashed token) when a logger is set" do
+      strio = StringIO.new
+      logger = Logger.new strio
+      creds.logger = logger
+
+      creds.apply({})
+
+      _(strio.string).wont_be:empty?
+      hashed_token = Digest::SHA256.hexdigest(token)
+      _(strio.string).must_include hashed_token # Check if the hash is logged.
+      _(strio.string).wont_include token # Explicitly check that the raw token is NOT logged.
+    end
+  end
+
+  describe "#token_type" do
+    it "defaults to :bearer_token" do
+        creds = Google::Auth::BearerTokenCredentials.new token: token
+        _(creds.token_type).must_equal :bearer_token
+    end
+    it "returns the provided token type" do
+        creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
+        _(creds.token_type).must_equal :access_token
+    end
+  end
+
+  describe "#duplicate" do
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expiry: expiry, token_type: :access_token}
+
+    it "creates a duplicate with same values" do
+      dup = creds.duplicate
+      _(dup.token).must_equal token
+      _(dup.expiry).must_equal expiry
+      _(dup.token_type).must_equal :access_token
+      _(dup.universe_domain).must_equal "googleapis.com"
+    end
+
+    it "allows overriding values" do
+      new_expiry = Time.now + 7200
+      dup = creds.duplicate token: "new-token", expiry: new_expiry, token_type: :jwt, universe_domain: example_universe_domain
+      _(dup.token).must_equal "new-token"
+      _(dup.expiry).must_equal new_expiry
+      _(dup.token_type).must_equal :jwt
+      _(dup.universe_domain).must_equal example_universe_domain
+    end
+  end
+
+  describe "#expires_within?" do
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expiry: expiry }
+
+    it "returns true if after expiry" do
+      _(creds.expires_within?(4000)).must_equal true # Check after expiry
+    end
+
+    it "returns false if before expiry" do
+      _(creds.expires_within?(3000)).must_equal false # Check before expiry
+    end
+
+    it "returns false if no expiry is set" do
+      creds_no_expiry = Google::Auth::BearerTokenCredentials.new token: token
+      _(creds_no_expiry.expires_within?(3600)).must_equal false
+    end
+  end
+end

--- a/test/bearer_token_test.rb
+++ b/test/bearer_token_test.rb
@@ -1,4 +1,4 @@
-  # Copyright 2025 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ require "digest"
 describe Google::Auth::BearerTokenCredentials do
   let(:token) { "test-bearer-token-12345" }
   let(:example_universe_domain) { "example.com" }
-  let(:expiry) { Time.now + 3600 } # 1 hour from now
+  let(:expires_at) { Time.now + 3600 } # 1 hour from now
 
   describe "#initialize" do
     it "creates with token and proper defaults" do
@@ -38,15 +38,15 @@ describe Google::Auth::BearerTokenCredentials do
       _(creds.universe_domain).must_equal example_universe_domain
     end
 
-    it "creates with expiry as Time object" do
-      creds = Google::Auth::BearerTokenCredentials.new(token: token, expiry: expiry)
-      _(creds.expiry).must_equal expiry
+    it "creates with expires_at as Time object" do
+      creds = Google::Auth::BearerTokenCredentials.new(token: token, expires_at: expires_at)
+      _(creds.expires_at).must_equal expires_at
     end
 
-    it "creates with expiry as Numeric timestamp" do
-      expiry_seconds = expiry.to_i
-      creds = Google::Auth::BearerTokenCredentials.new(token: token, expiry: expiry_seconds)
-      _(creds.expiry).must_equal Time.at(expiry_seconds)
+    it "creates with expires_at as Numeric timestamp" do
+      expires_at_seconds = expires_at.to_i
+      creds = Google::Auth::BearerTokenCredentials.new(token: token, expires_at: expires_at_seconds)
+      _(creds.expires_at).must_equal Time.at(expires_at_seconds)
     end
 
     it "creates with custom token type" do
@@ -60,7 +60,7 @@ describe Google::Auth::BearerTokenCredentials do
       end.must_raise ArgumentError
     end
 
-     it "raises if bearer token is empty" do
+    it "raises if bearer token is empty" do
       expect do
         Google::Auth::BearerTokenCredentials.new(token: "")
       end.must_raise ArgumentError
@@ -78,79 +78,99 @@ describe Google::Auth::BearerTokenCredentials do
 
     it "adds Authorization token header to hash" do
       md = { foo: "bar" }
-      want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
+      want = { foo: "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
       md = creds.apply md
       _(md).must_equal want
     end
 
     it "Token type does not influence the header value" do
-        creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
-        md = { foo: "bar" }
-        want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
-        md = creds.apply md
-        _(md).must_equal want
-    end
+      creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
+      md = { foo: "bar" }
+      want = { foo: "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
+      md = creds.apply md
+      _(md).must_equal want
+  end
 
-    it "logs (hashed token) when a logger is set" do
+    it "logs (hashed token) when a logger is set, but not the raw token" do
       strio = StringIO.new
       logger = Logger.new strio
       creds.logger = logger
-
       creds.apply({})
-
       _(strio.string).wont_be:empty?
+
       hashed_token = Digest::SHA256.hexdigest(token)
-      _(strio.string).must_include hashed_token # Check if the hash is logged.
-      _(strio.string).wont_include token # Explicitly check that the raw token is NOT logged.
+      _(strio.string).must_include hashed_token
+      _(strio.string).wont_include token
     end
   end
 
   describe "#token_type" do
     it "defaults to :bearer_token" do
-        creds = Google::Auth::BearerTokenCredentials.new token: token
-        _(creds.token_type).must_equal :bearer_token
+      creds = Google::Auth::BearerTokenCredentials.new token: token
+      _(creds.token_type).must_equal :bearer_token
     end
+
     it "returns the provided token type" do
-        creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
-        _(creds.token_type).must_equal :access_token
+      creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
+      _(creds.token_type).must_equal :access_token
     end
   end
 
   describe "#duplicate" do
-    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expiry: expiry, token_type: :access_token}
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expires_at: expires_at, token_type: :access_token }
 
     it "creates a duplicate with same values" do
       dup = creds.duplicate
       _(dup.token).must_equal token
-      _(dup.expiry).must_equal expiry
+      _(dup.expires_at).must_equal expires_at
       _(dup.token_type).must_equal :access_token
       _(dup.universe_domain).must_equal "googleapis.com"
     end
 
     it "allows overriding values" do
-      new_expiry = Time.now + 7200
-      dup = creds.duplicate token: "new-token", expiry: new_expiry, token_type: :jwt, universe_domain: example_universe_domain
+      new_expires_at = Time.now + 7200
+      dup = creds.duplicate token: "new-token", expires_at: new_expires_at, token_type: :jwt, universe_domain: example_universe_domain
       _(dup.token).must_equal "new-token"
-      _(dup.expiry).must_equal new_expiry
+      _(dup.expires_at).must_equal new_expires_at
       _(dup.token_type).must_equal :jwt
       _(dup.universe_domain).must_equal example_universe_domain
     end
   end
 
   describe "#expires_within?" do
-    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expiry: expiry }
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expires_at: expires_at }
 
-    it "returns true if after expiry" do
-      _(creds.expires_within?(4000)).must_equal true # Check after expiry
+    it "returns true if after expiration" do
+      _(creds.expires_within?(4000)).must_equal true # Check after expiration
     end
 
-    it "returns false if before expiry" do
-      _(creds.expires_within?(3000)).must_equal false # Check before expiry
+    it "returns false if before expiration" do
+      _(creds.expires_within?(3000)).must_equal false # Check before expiration
     end
 
-    it "returns false if no expiry is set" do
-      creds_no_expiry = Google::Auth::BearerTokenCredentials.new token: token
-      _(creds_no_expiry.expires_within?(3600)).must_equal false
+    it "returns false if no expiration is set" do
+      creds_no_expires_at = Google::Auth::BearerTokenCredentials.new token: token
+      _(creds_no_expires_at.expires_within?(3600)).must_equal false
+    end
+  end
+
+  describe "#fetch_access_token!" do
+    it "returns nil if not expired" do
+      creds = Google::Auth::BearerTokenCredentials.new token: token, expires_at: expires_at
+      _(creds.send(:fetch_access_token!)).must_be_nil
+    end
+
+    it "raises if token is expired" do
+      expired_time = Time.now - 3600
+      creds = Google::Auth::BearerTokenCredentials.new token: token, expires_at: expired_time
+      expect do
+        creds.send(:fetch_access_token!)
+      end.must_raise StandardError
+    end
+
+    it "returns nil if no expiry is set" do
+      creds = Google::Auth::BearerTokenCredentials.new token: token
+      _(creds.send(:fetch_access_token!)).must_be_nil
     end
   end
 end

--- a/test/bearer_token_test.rb
+++ b/test/bearer_token_test.rb
@@ -26,7 +26,6 @@ describe Google::Auth::BearerTokenCredentials do
     it "creates with token and proper defaults" do
       creds = Google::Auth::BearerTokenCredentials.new token: token
       _(creds.token).must_equal token
-      _(creds.token_type).must_equal :bearer_token
       _(creds.universe_domain).must_equal "googleapis.com"
     end
 
@@ -49,11 +48,6 @@ describe Google::Auth::BearerTokenCredentials do
       _(creds.expires_at).must_equal Time.at(expires_at_seconds)
     end
 
-    it "creates with custom token type" do
-      creds = Google::Auth::BearerTokenCredentials.new(token: token, token_type: :access_token)
-      _(creds.token_type).must_equal :access_token
-    end
-
     it "raises if bearer token is missing" do
       expect do
         Google::Auth::BearerTokenCredentials.new
@@ -63,12 +57,6 @@ describe Google::Auth::BearerTokenCredentials do
     it "raises if bearer token is empty" do
       expect do
         Google::Auth::BearerTokenCredentials.new(token: "")
-      end.must_raise ArgumentError
-    end
-
-    it "raises if invalid token type is provided" do
-      expect do
-        Google::Auth::BearerTokenCredentials.new(token: token, token_type: :invalid)
       end.must_raise ArgumentError
     end
   end
@@ -83,14 +71,6 @@ describe Google::Auth::BearerTokenCredentials do
       _(md).must_equal want
     end
 
-    it "Token type does not influence the header value" do
-      creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
-      md = { foo: "bar" }
-      want = { foo: "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
-      md = creds.apply md
-      _(md).must_equal want
-  end
-
     it "logs (hashed token) when a logger is set, but not the raw token" do
       strio = StringIO.new
       logger = Logger.new strio
@@ -104,35 +84,21 @@ describe Google::Auth::BearerTokenCredentials do
     end
   end
 
-  describe "#token_type" do
-    it "defaults to :bearer_token" do
-      creds = Google::Auth::BearerTokenCredentials.new token: token
-      _(creds.token_type).must_equal :bearer_token
-    end
-
-    it "returns the provided token type" do
-      creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
-      _(creds.token_type).must_equal :access_token
-    end
-  end
-
   describe "#duplicate" do
-    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expires_at: expires_at, token_type: :access_token }
+    let(:creds) { Google::Auth::BearerTokenCredentials.new token: token, expires_at: expires_at }
 
     it "creates a duplicate with same values" do
       dup = creds.duplicate
       _(dup.token).must_equal token
       _(dup.expires_at).must_equal expires_at
-      _(dup.token_type).must_equal :access_token
       _(dup.universe_domain).must_equal "googleapis.com"
     end
 
     it "allows overriding values" do
       new_expires_at = Time.now + 7200
-      dup = creds.duplicate token: "new-token", expires_at: new_expires_at, token_type: :jwt, universe_domain: example_universe_domain
+      dup = creds.duplicate token: "new-token", expires_at: new_expires_at, universe_domain: example_universe_domain
       _(dup.token).must_equal "new-token"
       _(dup.expires_at).must_equal new_expires_at
-      _(dup.token_type).must_equal :jwt
       _(dup.universe_domain).must_equal example_universe_domain
     end
   end

--- a/test/bearer_token_test.rb
+++ b/test/bearer_token_test.rb
@@ -78,7 +78,7 @@ describe Google::Auth::BearerTokenCredentials do
 
     it "adds Authorization token header to hash" do
       md = { foo: "bar" }
-      want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTHORIZATION_HEADER_NAME => "Bearer #{token}" }
+      want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
       md = creds.apply md
       _(md).must_equal want
     end
@@ -86,7 +86,7 @@ describe Google::Auth::BearerTokenCredentials do
     it "Token type does not influence the header value" do
         creds = Google::Auth::BearerTokenCredentials.new token: token, token_type: :access_token
         md = { foo: "bar" }
-        want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTHORIZATION_HEADER_NAME => "Bearer #{token}" }
+        want = {:foo => "bar", Google::Auth::BearerTokenCredentials::AUTH_METADATA_KEY => "Bearer #{token}" }
         md = creds.apply md
         _(md).must_equal want
     end


### PR DESCRIPTION
Bearer tokens are strings representing an authorization grant. They can be OAuth2 ("ya.29") tokens, JWTs, IDTokens -- anything that is sent as a `Bearer` in an `Authorization` header.

This new credentials type should be used when the end-user is managing the authentication token separately, e.g. with a separate service.