### PR TITLE
chore: Fix new rubocop warnings

### DIFF
--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -87,7 +87,7 @@ module Google
       def initialize options = {}
         # Override the constructor to remember whether the universe domain was
         # overridden by a constructor argument.
-        @universe_domain_overridden = options["universe_domain"] || options[:universe_domain] ? true : false
+        @universe_domain_overridden = options["universe_domain"] || options[:universe_domain]
         # TODO: Remove when universe domain metadata endpoint is stable (see b/349488459).
         @disable_universe_domain_check = true
         super options

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -395,8 +395,8 @@ describe Google::Auth::GCECredentials do
     end
 
     it "should duplicate the universe_domain_overridden" do
-      expect(@creds.instance_variable_get(:@universe_domain_overridden)).to eq false
-      expect(@creds.duplicate(universe_domain_overridden: true).instance_variable_get(:@universe_domain_overridden)).to eq true
+      expect(@creds.instance_variable_get(:@universe_domain_overridden)).to be_falsey
+      expect(@creds.duplicate(universe_domain_overridden: true).instance_variable_get(:@universe_domain_overridden)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
The `x ? true : false` idiom is now getting flagged by rubocop under `Style/RedundantCondition`. I would argue this is a false positive, but I don't have confidence that is a popular enough opinion to cause rubocop to revert its behavior. In any case, we can avoid the problem by making the change in this PR. This does change the internal functionality, as `@universe_domain_overridden` is now merely truthy/falsey rather than strictly `true` or `false`. However, it should only get used internally (in a context where we don't care about the strict type), so that shouldn't matter.