### PR TITLE
docs: add summary documentation on credentials types and improve YARD comments

### DIFF
--- a/Credentials.md
+++ b/Credentials.md
@@ -1,0 +1,106 @@
+# Introduction
+
+The closest thing to a base credentials class is the `BaseClient` module. 
+It includes functionality common to most credentials, such as applying authentication tokens to request headers, managing token expiration and refresh, handling logging, and providing updater procs for API clients.
+
+Many credentials classes inherit from `Signet::OAuth2::Client` (`lib/googleauth/signet.rb`) class which provides OAuth-based authentication.
+The `Signet::OAuth2::Client` includes the `BaseClient` functionality.
+
+Most credential types either inherit from `Signet::OAuth2::Client` or include the `BaseClient` module directly.
+
+Notably, `Google::Auth::Credentials` (`lib/googleauth/credentials.rb`) is not a base type or a credentials type per se. It is a wrapper for other credential classes
+that exposes common initialization functionality, such as creating credentials from environment variables, default paths, or application defaults. It is used and subclassed by Google's API client libraries.
+
+# List of credentials types
+
+## Simple Authentication (non-OAuth)
+
+**Google::Auth::APIKeyCredentials** - `lib/googleauth/api_key.rb`
+   - Includes `Google::Auth::BaseClient` module
+   - Implements Google API Key authentication
+   - API Keys are text strings that don't have an associated JSON file
+   - API Keys provide project information but don't reference an IAM principal
+   - They do not expire and cannot be refreshed
+   - Can be loaded from the `GOOGLE_API_KEY` environment variable
+
+2. **Google::Auth::BearerTokenCredentials** - `lib/googleauth/bearer_token.rb`
+   - Includes `Google::Auth::BaseClient` module
+   - Implements Bearer Token authentication
+   - Bearer tokens are strings representing an authorization grant
+   - Can be OAuth2 tokens, JWTs, ID tokens, or any token sent as a `Bearer` in an `Authorization` header
+   - Used when the end-user is managing the token separately (e.g., with another service)
+   - Token lifetime tracking and refresh are outside this class's scope
+   - No JSON representation for this type of credentials
+
+## GCP-Specialized authentication
+
+3. **Google::Auth::GCECredentials < Signet::OAuth2::Client** - `lib/googleauth/compute_engine.rb`
+   - For obtaining authentication tokens from GCE metadata server
+   - Used automatically when code is running on Google Compute Engine
+   - Fetches tokens from the metadata server with no additional configuration needed
+
+4. **Google::Auth::IAMCredentials < Signet::OAuth2::Client** - `lib/googleauth/iam.rb`
+   - For IAM-based authentication (e.g. service-to-service)
+   - Implements authentication-as-a-service for systems already authenticated
+   - Exchanges existing credentials for a short-lived access token
+
+## Service Account Authentication
+
+5. **Google::Auth::ServiceAccountCredentials < Signet::OAuth2::Client** - `lib/googleauth/service_account.rb`
+   - Authenticates requests using Service Account credentials via an OAuth access token
+   - Created from JSON key file downloaded from Google Cloud Console
+   - Supports both OAuth access tokens and self-signed JWT authentication
+   - Can specify scopes for access token requests
+
+6. **Google::Auth::ServiceAccountJwtHeaderCredentials** - `lib/googleauth/service_account_jwt_header.rb`
+   - Authenticates using Service Account credentials with JWT headers
+   - Typically used via `ServiceAccountCredentials` and not by itself
+   - Creates JWT directly for making authenticated calls
+   - Does not require a round trip to the authorization server
+   - Doesn't support OAuth scopes - uses audience (target API) instead
+
+7. **Google::Auth::ImpersonatedServiceAccountCredentials < Signet::OAuth2::Client** - `lib/googleauth/impersonated_service_account.rb`
+   - For service account impersonation
+   - Allows a GCP principal identified by a set of source credentials to impersonate a service account
+   - Useful for delegation of authority and managing permissions across service accounts
+   - Source credentials must have the Service Account Token Creator role on the target
+
+## User Authentication
+
+8. **Google::Auth::UserRefreshCredentials < Signet::OAuth2::Client** - `lib/googleauth/user_refresh.rb`
+   - For user refresh token authentication (from 3-legged OAuth flow)
+   - Authenticates on behalf of a user who has authorized the application
+   - Handles token refresh when original access token expires
+   - Typically obtained through web or installed application flow
+
+`Google::Auth::UserAuthorizer` (`lib/googleauth/user_authorizer.rb`) and `Google::Auth::WebUserAuthorizer` (`lib/googleauth/web_user_authorizer.rb`)
+ are used to facilitate user authentication. The `UserAuthorizer` handles interactive 3-Legged-OAuth2 (3LO) user consent authorization for command-line applications.
+ The `WebUserAuthorizer` is a variation of UserAuthorizer adapted for Rack-based web applications that manages OAuth state and provides callback handling.
+
+## External Account Authentication
+  `Google::Auth::ExternalAccount::Credentials` (`lib/googleauth/external_account.rb`) is not a credentials type, it is a module
+  that procides an entry point for External Account credentials. It also serves as a factory that creates appropriate credential
+  types based on credential source (similar to `Google::Auth::get_application_default`).
+  It is included in all External Account credentials types, and it itself includes `Google::Auth::BaseClient` module so all External
+  Account credentials types include `Google::Auth::BaseClient`.
+
+9. **Google::Auth::ExternalAccount::AwsCredentials** - `lib/googleauth/external_account/aws_credentials.rb`
+     - Includes `Google::Auth::BaseClient` module
+     - Includes `ExternalAccount::BaseCredentials` module
+     - Uses AWS credentials to authenticate to Google Cloud
+     - Exchanges temporary AWS credentials for Google access tokens
+     - Used for workloads running on AWS that need to access Google Cloud
+
+10. **Google::Auth::ExternalAccount::IdentityPoolCredentials** - `lib/googleauth/external_account/identity_pool_credentials.rb`
+     - Includes `Google::Auth::BaseClient` module
+     - Includes `ExternalAccount::BaseCredentials` module
+     - Authenticates using external identity pool
+     - Exchanges external identity tokens for Google access tokens
+     - Supports file-based and URL-based credential sources
+
+11. **Google::Auth::ExternalAccount::PluggableCredentials** - `lib/googleauth/external_account/pluggable_credentials.rb`
+     - Includes `Google::Auth::BaseClient` module
+     - Includes `ExternalAccount::BaseCredentials` module
+     - Supports executable-based credential sources
+     - Executes external programs to retrieve credentials
+     - Allows for custom authentication mechanisms via external executables

--- a/lib/googleauth/api_key.rb
+++ b/lib/googleauth/api_key.rb
@@ -85,6 +85,7 @@ module Google
       # @option options [String] :universe_domain
       #   The universe domain of the universe this API key
       #   belongs to (defaults to googleapis.com)
+      # @raise [ArgumentError] If the API key is nil or empty
       def initialize options = {}
         raise ArgumentError, "API key must be provided" if options[:api_key].nil? || options[:api_key].empty?
         @api_key = options[:api_key]
@@ -137,6 +138,14 @@ module Google
           Google::Logging::Message.from message: "Sending API key auth token. (sha256:#{hash})"
         end
         a_hash
+      end
+
+      # For credentials that are initialized with a token without a principal,
+      # the type of that token should be returned as a principal instead
+      # @private
+      # @return [Symbol] the token type in lieu of the principal
+      def principal
+        token_type
       end
 
       protected

--- a/lib/googleauth/base_client.rb
+++ b/lib/googleauth/base_client.rb
@@ -78,6 +78,11 @@ module Google
       # The logger used to log operations on this client, such as token refresh.
       attr_accessor :logger
 
+      # @private
+      def principal
+        raise NoMethodError, "principal not implemented"
+      end
+
       private
 
       def token_type

--- a/lib/googleauth/bearer_token.rb
+++ b/lib/googleauth/bearer_token.rb
@@ -119,6 +119,14 @@ module Google
         )
       end
 
+      # For credentials that are initialized with a token without a principal,
+      # the type of that token should be returned as a principal instead
+      # @private
+      # @return [Symbol] the token type in lieu of the principal
+      def principal
+        token_type
+      end
+
       protected
 
       ##

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -175,6 +175,13 @@ module Google
         self
       end
 
+      # Returns the principal identifier for GCE credentials
+      # @private
+      # @return [Symbol] :gce to represent Google Compute Engine identity
+      def principal
+        :gce_metadata
+      end
+
       private
 
       def log_fetch_query

--- a/lib/googleauth/external_account/base_credentials.rb
+++ b/lib/googleauth/external_account/base_credentials.rb
@@ -89,6 +89,14 @@ module Google
           %r{/iam\.googleapis\.com/locations/[^/]+/workforcePools/}.match?(@audience || "")
         end
 
+        # For external account credentials, the principal is
+        # represented by the audience, such as a workforce pool
+        # @private
+        # @return [String] the GCP principal, e.g. a workforce pool
+        def principal
+          @audience
+        end
+
         private
 
         def token_type

--- a/lib/googleauth/external_account/external_account_utils.rb
+++ b/lib/googleauth/external_account/external_account_utils.rb
@@ -36,8 +36,8 @@ module Google
         # call this API or the required scopes may not be selected:
         # https://cloud.google.com/resource-manager/reference/rest/v1/projects/get#authorization-scopes
         #
-        # @return [string,nil]
-        #     The project ID corresponding to the workload identity pool or workforce pool if determinable.
+        # @return [String, nil] The project ID corresponding to the workload identity
+        #   pool or workforce pool if determinable
         #
         def project_id
           return @project_id unless @project_id.nil?
@@ -65,7 +65,8 @@ module Google
         # STS audience pattern:
         #     `//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/...`
         #
-        # @return [string, nil]
+        # @return [String, nil] The project number extracted from the audience string,
+        #   or nil if it cannot be determined
         #
         def project_number
           segments = @audience.split "/"
@@ -74,6 +75,10 @@ module Google
           segments[idx + 1]
         end
 
+        # Normalizes a timestamp value to a Time object
+        #
+        # @param time [Time, String, nil] The timestamp to normalize
+        # @return [Time, nil] The normalized timestamp or nil if input is nil
         def normalize_timestamp time
           case time
           when NilClass
@@ -87,6 +92,10 @@ module Google
           end
         end
 
+        # Extracts the service account email from the impersonation URL
+        #
+        # @return [String, nil] The service account email extracted from the
+        #   service_account_impersonation_url, or nil if it cannot be determined
         def service_account_email
           return nil if @service_account_impersonation_url.nil?
           start_idx = @service_account_impersonation_url.rindex "/"

--- a/lib/googleauth/iam.rb
+++ b/lib/googleauth/iam.rb
@@ -52,8 +52,17 @@ module Google
 
       # Returns a reference to the #apply method, suitable for passing as
       # a closure
+      #
+      # @return [Proc] A procedure that updates a hash with credentials
       def updater_proc
         proc { |a_hash, _opts = {}| apply a_hash }
+      end
+
+      # Returns the IAM authority selector as the principal
+      # @private
+      # @return [String] the IAM authoirty selector
+      def principal
+        @selector
       end
     end
   end

--- a/lib/googleauth/id_tokens/verifier.rb
+++ b/lib/googleauth/id_tokens/verifier.rb
@@ -61,10 +61,9 @@ module Google
         # @param iss [String,nil] If given, override the `iss` check.
         #
         # @return [Hash] the decoded payload, if verification succeeded.
-        # @raise [KeySourceError] if the key source failed to obtain public keys
-        # @raise [VerificationError] if the token verification failed.
+        # @raise [Google::Auth::IDTokens::KeySourceError] if the key source failed to obtain public keys
+        # @raise [Google::Auth::IDTokens::VerificationError] if the token verification failed.
         #     Additional data may be available in the error subclass and message.
-        #
         def verify token,
                    key_source: :default,
                    aud:        :default,

--- a/lib/googleauth/impersonated_service_account.rb
+++ b/lib/googleauth/impersonated_service_account.rb
@@ -191,6 +191,20 @@ module Google
         self.class.new options
       end
 
+      # The principal behind the credentials. This class allows custom source credentials type
+      # that might not implement `principal`, in which case `:unknown` is returned.
+      #
+      # @private
+      # @return [String, Symbol] The string representation of the principal,
+      #     the token type in lieu of the principal, or :unknown if source principal is unknown.
+      def principal
+        if @source_credentials.respond_to? :principal
+          @source_credentials.principal
+        else
+          :unknown
+        end
+      end
+
       private
 
       # Generates a new impersonation access token by exchanging the source credentials' token

--- a/lib/googleauth/scope_util.rb
+++ b/lib/googleauth/scope_util.rb
@@ -57,7 +57,7 @@ module Google
       #
       # @param scope [String,Array<String>] Input scope(s)
       # @return [Array<String>] Always an array of strings
-      # @raise ArgumentError If the input is not a string or array of strings
+      # @raise [ArgumentError] If the input is not a string or array of strings
       #
       def self.as_array scope
         case scope

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -51,8 +51,9 @@ module Google
 
       # Creates a ServiceAccountCredentials.
       #
-      # @param json_key_io [IO] an IO from which the JSON key can be read
+      # @param json_key_io [IO] An IO object containing the JSON key
       # @param scope [string|array|nil] the scope(s) to access
+      # @raise [ArgumentError] If both scope and target_audience are specified
       def self.make_creds options = {}
         json_key_io, scope, enable_self_signed_jwt, target_audience, audience, token_credential_uri =
           options.values_at :json_key_io, :scope, :enable_self_signed_jwt, :target_audience,
@@ -110,6 +111,9 @@ module Google
       # Handles certain escape sequences that sometimes appear in input.
       # Specifically, interprets the "\n" sequence for newline, and removes
       # enclosing quotes.
+      #
+      # @param str [String] The string to unescape
+      # @return [String] The unescaped string
       def self.unescape str
         str = str.gsub '\n', "\n"
         str = str[1..-2] if str.start_with?('"') && str.end_with?('"')
@@ -162,6 +166,13 @@ module Google
         super(options)
 
         self
+      end
+
+      # Returns the client email as the principal for service account credentials
+      # @private
+      # @return [String] the email address of the service account
+      def principal
+        @issuer
       end
 
       private

--- a/lib/googleauth/service_account_jwt_header.rb
+++ b/lib/googleauth/service_account_jwt_header.rb
@@ -47,7 +47,7 @@ module Google
 
       # Create a ServiceAccountJwtHeaderCredentials.
       #
-      # @param json_key_io [IO] an IO from which the JSON key can be read
+      # @param json_key_io [IO] An IO object containing the JSON key
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
         json_key_io, scope = options.values_at :json_key_io, :scope
@@ -56,7 +56,7 @@ module Google
 
       # Initializes a ServiceAccountJwtHeaderCredentials.
       #
-      # @param json_key_io [IO] an IO from which the JSON key can be read
+      # @param json_key_io [IO] An IO object containing the JSON key
       def initialize options = {}
         json_key_io = options[:json_key_io]
         if json_key_io
@@ -157,6 +157,13 @@ module Google
       # Duck-types the corresponding method from BaseClient
       def needs_access_token?
         false
+      end
+
+      # Returns the client email as the principal for service account JWT header credentials
+      # @private
+      # @return [String] the email address of the service account
+      def principal
+        @issuer
       end
 
       private

--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -269,6 +269,15 @@ module Google
         SecureRandom.alphanumeric random_number
       end
 
+      # Returns the principal identifier for this authorizer
+      # The client ID is used as the principal for user authorizers
+      #
+      # @private
+      # @return [String] The client ID associated with this authorizer
+      def principal
+        @client_id.id
+      end
+
       private
 
       # @private Fetch stored token with given user_id

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -40,7 +40,7 @@ module Google
 
       # Create a UserRefreshCredentials.
       #
-      # @param json_key_io [IO] an IO from which the JSON key can be read
+      # @param json_key_io [IO] An IO object containing the JSON key
       # @param scope [string|array|nil] the scope(s) to access
       def self.make_creds options = {}
         json_key_io, scope = options.values_at :json_key_io, :scope
@@ -64,8 +64,11 @@ module Google
           .configure_connection(options)
       end
 
-      # Reads the client_id, client_secret and refresh_token fields from the
-      # JSON key.
+      # Reads a JSON key from an IO object and extracts required fields.
+      #
+      # @param [IO] json_key_io An IO object containing the JSON key
+      # @return [Hash] The parsed JSON key
+      # @raise [Google::Auth::Error] If the JSON is missing required fields
       def self.read_json_key json_key_io
         json_key = MultiJson.load json_key_io.read
         wanted = ["client_id", "client_secret", "refresh_token"]
@@ -156,6 +159,13 @@ module Google
         super(options)
 
         self
+      end
+
+      # Returns the client ID as the principal for user refresh credentials
+      # @private
+      # @return [String, Symbol] the client ID or :user_refresh if not available
+      def principal
+        @client_id || :user_refresh
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,3 +17,24 @@ require "minitest/focus"
 require "webmock/minitest"
 
 require "googleauth"
+
+##
+# A simple in-memory implementation of TokenStore
+# for UserAuthorizer initialization when testing
+class TestTokenStore
+    def initialize
+        @tokens = {}
+    end
+
+    def load id
+        @tokens[id]
+    end
+
+    def store id, token
+        @tokens[id] = token
+    end
+
+    def delete id
+        @tokens.delete id
+    end
+end

--- a/test/principal_test.rb
+++ b/test/principal_test.rb
@@ -1,0 +1,190 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+require "stringio"
+require "multi_json"
+
+require "googleauth/api_key"
+require "googleauth/bearer_token"
+require "googleauth/client_id"
+require "googleauth/compute_engine"
+require "googleauth/external_account"
+require "googleauth/iam"
+require "googleauth/service_account"
+require "googleauth/service_account_jwt_header"
+require "googleauth/impersonated_service_account"
+require "googleauth/user_refresh"
+require "googleauth/user_authorizer"
+
+describe "Principal methods" do
+  describe "APIKeyCredentials" do
+    it "returns :api_key as principal" do
+      creds = Google::Auth::APIKeyCredentials.new api_key: "test-api-key"
+      _(creds.principal).must_equal :api_key
+    end
+  end
+
+  describe "BearerTokenCredentials" do
+    it "returns :bearer_token as principal" do
+      creds = Google::Auth::BearerTokenCredentials.new token: "test-token"
+      _(creds.principal).must_equal :bearer_token
+    end
+  end
+
+  describe "GCECredentials" do
+    it "returns :gce_metadata as principal" do
+      creds = Google::Auth::GCECredentials.new
+      _(creds.principal).must_equal :gce_metadata
+    end
+  end
+
+  describe "IAMCredentials" do
+    it "returns the selector as principal" do
+      selector = "test-selector"
+      creds = Google::Auth::IAMCredentials.new selector, "test-token"
+      _(creds.principal).must_equal selector
+    end
+  end
+
+  describe "ServiceAccountCredentials" do
+    it "returns the issuer as principal" do
+      test_email = "test-service-account@example.project.iam.gserviceaccount.com"
+      json = {
+        private_key:  @key = OpenSSL::PKey::RSA.new(2048).to_pem,
+        client_email: test_email
+      }
+      key_io = StringIO.new MultiJson.dump(json)
+      creds = Google::Auth::ServiceAccountCredentials.make_creds json_key_io: key_io
+      _(creds.principal).must_equal test_email
+    end
+  end
+
+  describe "ServiceAccountJwtHeaderCredentials" do
+    it "returns the issuer as principal" do
+      test_email = "test-service-account@example.project.iam.gserviceaccount.com"
+      json = {
+        private_key:  @key = OpenSSL::PKey::RSA.new(2048).to_pem,
+        client_email: test_email
+      }
+      key_io = StringIO.new MultiJson.dump(json)
+      creds = Google::Auth::ServiceAccountJwtHeaderCredentials.make_creds json_key_io: key_io
+      _(creds.principal).must_equal test_email
+    end
+  end
+
+  describe "ImpersonatedServiceAccountCredentials" do
+    it "returns the source principal when source has a principal method" do
+      source_creds = Object.new
+      def source_creds.updater_proc
+        proc { |a_hash, _opts = {}| a_hash }
+      end
+
+      def source_creds.principal
+        :custom_principal
+      end
+
+      test_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/target@example.com:generateAccessToken"
+      test_scope = ["https://www.googleapis.com/auth/userinfo.email"]
+      creds = Google::Auth::ImpersonatedServiceAccountCredentials.new(
+        source_credentials: source_creds,
+        impersonation_url: test_impersonation_url,
+        scope: test_scope
+      )
+      _(creds.principal).must_equal :custom_principal
+    end
+
+    it "returns :unknown when source doesn't have a principal method" do
+      source_creds = Object.new
+      def source_creds.updater_proc
+        proc { |a_hash, _opts = {}| a_hash }
+      end
+
+      test_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/target@example.com:generateAccessToken"
+      test_scope = ["https://www.googleapis.com/auth/userinfo.email"]
+      creds = Google::Auth::ImpersonatedServiceAccountCredentials.new(
+        source_credentials: source_creds,
+        impersonation_url: test_impersonation_url,
+        scope: test_scope
+      )
+      _(creds.principal).must_equal :unknown
+    end
+  end
+
+  describe "UserRefreshCredentials" do
+    it "returns the client_id as principal when available" do
+      test_client_id = "test-client-id.apps.googleusercontent.com"
+      json = {
+        client_id: test_client_id,
+        client_secret: "notsosecret",
+        refresh_token: "refreshing-token"
+      }
+      key_io = StringIO.new MultiJson.dump(json)
+      creds = Google::Auth::UserRefreshCredentials.make_creds json_key_io: key_io
+      _(creds.principal).must_equal test_client_id
+    end
+
+    it "returns :user_refresh when client_id not available" do
+      # This isn't a typical initialization path, but we need to test the fallback
+      creds = Google::Auth::UserRefreshCredentials.new
+      _(creds.principal).must_equal :user_refresh
+    end
+  end
+
+  describe "UserAuthorizer" do
+    let :expected_client_id do
+      "test-client-id.apps.googleusercontent.com"
+    end
+
+    let :client_id do
+      Google::Auth::ClientId.new(
+        expected_client_id,
+        "notsosecret"
+      )
+    end
+
+    it "returns the client id as principal" do
+      require "googleauth/token_store"
+      require "googleauth/stores/file_token_store"
+      scope = ["https://www.googleapis.com/auth/userinfo.email"]
+      token_store = Google::Auth::Stores::FileTokenStore.new file: "/dev/null"
+      authorizer = Google::Auth::UserAuthorizer.new(
+        client_id,
+        scope,
+        token_store
+      )
+      _(authorizer.principal).must_equal expected_client_id
+    end
+  end
+
+  describe "External Account Base Credentials" do
+    it "returns audience as principal" do
+      # Create a test class inline that includes the module
+      test_class = Class.new do
+        include Google::Auth::ExternalAccount::BaseCredentials
+
+        attr_reader :audience
+
+        def initialize audience
+          @audience = audience
+        end
+      end
+
+      test_audience = "//iam.googleapis.com/projects/test-project/locations/global/workforce-pools/test"
+      creds = test_class.new test_audience
+      _(creds.principal).must_equal test_audience
+    end
+  end
+end

--- a/test/principal_test.rb
+++ b/test/principal_test.rb
@@ -156,10 +156,8 @@ describe "Principal methods" do
     end
 
     it "returns the client id as principal" do
-      require "googleauth/token_store"
-      require "googleauth/stores/file_token_store"
       scope = ["https://www.googleapis.com/auth/userinfo.email"]
-      token_store = Google::Auth::Stores::FileTokenStore.new file: "/dev/null"
+      token_store = TestTokenStore.new
       authorizer = Google::Auth::UserAuthorizer.new(
         client_id,
         scope,


### PR DESCRIPTION
This PR adds a `principal` getter to credentials. The `principal` is safe to log and is implemented as follows:
  1. APIKeyCredentials - returns :api_key
  2. BearerTokenCredentials - returns :bearer_token
  3. GCECredentials - returns :gce_metadata
  4. IAMCredentials - returns the selector
  5. ServiceAccountCredentials - returns the service account email (issuer)
  6. ServiceAccountJwtHeaderCredentials - returns the service account email (issuer)
  7. ImpersonatedServiceAccountCredentials - returns the source principal when available, or :unknown
  8. UserRefreshCredentials - returns client_id or falls back to :user_refresh
  9. UserAuthorizer - returns the client ID
  10. ExternalAccount::BaseCredentials - returns the audience

Also added a `Credentials.md` documenting the available credentials.

There are also minor doc and comment improvements along the way. 
This is to be used in the error details work, to reduce the size of upcoming PR.
