### PR TITLE
Make include_granted_scopes optional in UserAuthorizer

### DIFF
--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -117,12 +117,12 @@ module Google
           additional_parameters: options[:additional_parameters]
         )
         redirect_uri = redirect_uri_for options[:base_url]
-        url = credentials.authorization_uri(access_type:            "offline",
-                                            redirect_uri:           redirect_uri,
-                                            approval_prompt:        "force",
-                                            state:                  options[:state],
-                                            include_granted_scopes: true,
-                                            login_hint:             options[:login_hint])
+        url = credentials.authorization_uri(access_type:             "offline",
+                                            redirect_uri:            redirect_uri,
+                                            approval_prompt:         "force",
+                                            state:                   options[:state],
+                                            include_granted_scopes:  options[:include_granted_scopes] || false,
+                                            login_hint:              options[:login_hint])
         url.to_s
       end
 

--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -121,7 +121,7 @@ module Google
                                             redirect_uri:            redirect_uri,
                                             approval_prompt:         "force",
                                             state:                   options[:state],
-                                            include_granted_scopes:  options[:include_granted_scopes] || false,
+                                            include_granted_scopes:  options[:include_granted_scopes] || true,
                                             login_hint:              options[:login_hint])
         url.to_s
       end


### PR DESCRIPTION
This pull request updates the `get_authorization_url` method in the `lib/googleauth/user_authorizer.rb` file to make the `include_granted_scopes` parameter configurable through the `options` hash, with a default fallback to `true`.

Key change:

* [`lib/googleauth/user_authorizer.rb`](diffhunk://#diff-cdd0462a0156150d45c3ed02f11303fa04c1c5f684e8b6e6ce6f91f6fec5d81eL124-R124): Modified the `include_granted_scopes` parameter to use `options[:include_granted_scopes]` if provided, or default to `true`, allowing for more flexibility in the method's behavior.

When true, all previously approved scopes for the user and app combination is included in the approval. WHen set to false, only the explicitly supplied scopes are asked for granting.