### PR TITLE
feat: Support for JWT 3.x

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday", ">= 1.0", "< 3.a"
   gem.add_dependency "google-cloud-env", "~> 2.2"
   gem.add_dependency "google-logging-utils", "~> 0.1"
-  gem.add_dependency "jwt", ">= 1.4", "< 3.0"
+  gem.add_dependency "jwt", ">= 1.4", "< 4.0"
   gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
   gem.add_dependency "signet", ">= 0.16", "< 2.a"


### PR DESCRIPTION
Makes us compatible with JWT 1.x, 2.x, and 3.x. I've verified our usage remains compatible with 3.x.

Closes #541