### PR TITLE
Fix: Don't raise an error if `expiration_time_millis` is nil; fall back to 0

### DIFF
--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -156,7 +156,7 @@ module Google
           scope:         data["scope"] || @scope,
           access_token:  data["access_token"],
           refresh_token: data["refresh_token"],
-          expires_at:    data.fetch("expiration_time_millis", 0) / 1000
+          expires_at:    (data.fetch("expiration_time_millis") || 0) / 1000
         )
         scope ||= @scope
         return monitor_credentials user_id, credentials if credentials.includes_scope? scope


### PR DESCRIPTION
### The change

`data.fetch("expiration_time_millis", 0)` will default to 0 only if the key is not present. If the key is present but the associated value is nil, then prior to this change the code would raise as follows:

```
NoMethodError (undefined method `/' for nil:NilClass

          expires_at:    data.fetch("expiration_time_millis", 0) / 1000
                                                                 ^):

```

This commit updates the code to default to 0 if the key is not found or if the value is nil.

With the existing token stores, this situation may not arise, but it's a particular issue when using a custom token store where values could be nil, like a database.

### Testing

Since the existing tests don't cover the existing fallback, I've not added to them here either.

I've tested this change manually locally by modifying my copy of the gem in a test project.

### Changelog

https://github.com/googleapis/google-auth-library-ruby/blob/main/.github/CONTRIBUTING.md mentions updating the CHANGELOG. However, [CHANGELOG updates now appear to be an automated process](https://github.com/googleapis/google-auth-library-ruby/commits/main/CHANGELOG.md) so I've left this alone.