### PR TITLE
fix: missing auth header in impersonated service account credentials

### DIFF
--- a/lib/googleauth/impersonated_service_account.rb
+++ b/lib/googleauth/impersonated_service_account.rb
@@ -296,9 +296,7 @@ module Google
       # @private
       # @return [Hash] The authorization header with the source credentials' token
       def prepare_auth_header
-        auth_header = {}
-        @source_credentials.updater_proc.call auth_header
-        auth_header
+        @source_credentials.updater_proc.call {}
       end
 
       # Makes the HTTP request to the impersonation endpoint.


### PR DESCRIPTION
This fixes an issue reporting that service account impersonation isn't working: https://github.com/googleapis/google-auth-library-ruby/issues/353.

The fixed code changes how ImpersonatedServiceAccountCredentials adds the auth header to its client. The primary issue was that the hash passed into the `apply` function is not mutated. Instead, the underlying implementations copies the hash, performs authentication, then returns the copy. The `prepare_auth_header` method was changed to align with the underlying implementation.