### PR TITLE
fix: restore support for JSON keys missing 'type' field

### DIFF
--- a/lib/googleauth/external_account.rb
+++ b/lib/googleauth/external_account.rb
@@ -62,6 +62,13 @@ module Google
           json_key_io, scope = options.values_at :json_key_io, :scope
 
           raise InitializationError, "A json file is required for external account credentials." unless json_key_io
+          json_key = MultiJson.load json_key_io.read, symbolize_keys: true
+          if json_key.key? :type
+            json_key_io.rewind
+          else # Defaults to class credential 'type' if missing.
+            json_key[:type] = CREDENTIAL_TYPE_NAME
+            json_key_io = StringIO.new MultiJson.dump(json_key)
+          end
           CredentialsLoader.load_and_verify_json_key_type json_key_io, CREDENTIAL_TYPE_NAME
           user_creds = read_json_key json_key_io
 

--- a/spec/googleauth/external_account_spec.rb
+++ b/spec/googleauth/external_account_spec.rb
@@ -259,5 +259,27 @@ describe Google::Auth::ExternalAccount::Credentials do
         f.unlink
       end
     end
+
+    it 'should succeed if the credential type is missing (uses default)' do
+      f = Tempfile.new('missing_type')
+      begin
+        f.write(MultiJson.dump({
+          audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
+          subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+          token_url: 'https://sts.googleapis.com/v1/token',
+          credential_source: {
+            'file' => 'external_suject_token.txt'
+          },
+        }))
+        f.rewind
+        expect { Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f) }
+          .not_to raise_error(
+            Google::Auth::InitializationError, /The provided credentials were not of type 'external_account'/
+          )
+      ensure
+        f.close
+        f.unlink
+      end
+    end
   end
 end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -119,6 +119,17 @@ describe Google::Auth::ServiceAccountCredentials do
     )
   end
 
+  it "succeeds if the credential type is missing (uses default)" do
+    key_without_type = cred_json.reject { |k, _| k == :type }
+    expect do
+      ServiceAccountCredentials.make_creds(
+        json_key_io: StringIO.new(MultiJson.dump(key_without_type))
+      )
+    end.not_to raise_error(
+        Google::Auth::InitializationError, /The provided credentials were not of type 'service_account'/
+    )
+  end
+
   describe "universe_domain" do
     it "defaults to googleapis" do
       expect(@client.universe_domain).to eq("googleapis.com")

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -95,6 +95,17 @@ describe Google::Auth::UserRefreshCredentials do
     )
   end
 
+  it "succeeds if the credential type is missing (uses default)" do
+    key_without_type = cred_json.reject { |k, _| k == :type }
+    expect do
+      UserRefreshCredentials.make_creds(
+        json_key_io: StringIO.new(MultiJson.dump(key_without_type))
+      )
+    end.not_to raise_error(
+        Google::Auth::InitializationError, /The provided credentials were not of type 'authorized_user'/
+    )
+  end
+
   describe "#from_env" do
     before :example do
       @var_name = ENV_VAR


### PR DESCRIPTION
In v1.15.1, a strict type check was introduced which broke compatibility for JSON keys missing the 'type' field. 

This change restores support by defaulting to the expected credential type when calling via `make_credits` for `ServiceAccountCredentials`, `UserRefreshCredentials`, and `ExternalAccount::Credentials`.

Fixes #557
