### PR TITLE
fix: return response body from revoke! for logging pipeline

### DIFF
--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -210,10 +210,12 @@ module Signet
           digest = Digest::SHA256.hexdigest response_hash["id_token"]
           response_hash["id_token"] = "(sha256:#{digest})"
         end
-        Google::Logging::Message.from(
-          message: "Received auth token response: #{response_hash}",
-          "credentialsId" => object_id
-        )
+        logger&.debug do
+          Google::Logging::Message.from(
+            message: "Received auth token response: #{response_hash}",
+            "credentialsId" => object_id
+          )
+        end
       end
 
       def log_auth_error err

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -146,6 +146,8 @@ module Google
               principal: principal
             )
           end
+
+          resp.body
         end
       end
 

--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -176,6 +176,7 @@ describe Signet::OAuth2::Client do
         response = mocked_responses.shift
         response == :raise ? raise(Signet::RemoteServerError) : response
       end
+      expect(@client).to receive(:sleep).exactly(2).times.with(kind_of(Numeric))
       expect(@client.fetch_access_token!).to eq("success")
     end
 
@@ -185,6 +186,7 @@ describe Signet::OAuth2::Client do
         response = mocked_responses.shift
         response == :raise ? raise(Signet::RemoteServerError) : response
       end
+      expect(@client).to receive(:sleep).exactly(5).times.with(kind_of(Numeric))
       expect { @client.fetch_access_token! }.to raise_error Signet::AuthorizationError
     end
 

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -326,26 +326,36 @@ describe Google::Auth::UserRefreshCredentials do
   end
 
   describe "when revoking a refresh token" do
+    let(:response_body) { "{}" }
     let :stub do
       stub_request(:post, "https://oauth2.googleapis.com/revoke")
         .with(body: hash_including("token" => "refreshtoken"))
         .to_return(status:  200,
+                   body: response_body,
                    headers: { "Content-Type" => "application/json" })
     end
 
     before :example do
       stub
-      @client.revoke!
+      @result = @client.revoke!
     end
 
     it_behaves_like "revoked token"
+
+    # The return value is passed through retry_with_error's logging pipeline,
+    # which expects a JSON-parseable string.
+    it "returns the response body" do
+      expect(@result).to eq(response_body)
+    end
   end
 
   describe "when revoking an access token" do
+    let(:response_body) { "{}" }
     let :stub do
       stub_request(:post, "https://oauth2.googleapis.com/revoke")
         .with(body: hash_including("token" => "accesstoken"))
         .to_return(status:  200,
+                   body: response_body,
                    headers: { "Content-Type" => "application/json" })
     end
 
@@ -353,10 +363,16 @@ describe Google::Auth::UserRefreshCredentials do
       stub
       @client.refresh_token = nil
       @client.access_token = "accesstoken"
-      @client.revoke!
+      @result = @client.revoke!
     end
 
     it_behaves_like "revoked token"
+
+    # The return value is passed through retry_with_error's logging pipeline,
+    # which expects a JSON-parseable string.
+    it "returns the response body" do
+      expect(@result).to eq(response_body)
+    end
   end
 
   describe "when revoking an invalid token" do

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -394,10 +394,46 @@ describe Google::Auth::UserRefreshCredentials do
     end
   end
 
+  describe "logging during revoke" do
+    let(:response_body) { '{"foo": "bar"}' }
+    let :stub do
+      stub_request(:post, "https://oauth2.googleapis.com/revoke")
+        .with(body: hash_including("token" => "refreshtoken"))
+        .to_return(status:  200,
+                   body: response_body,
+                   headers: { "Content-Type" => "application/json" })
+    end
+
+    it "logs the response body" do
+      stub
+      strio = StringIO.new
+      logger = Logger.new strio
+      logger.level = Logger::DEBUG
+      @client.logger = logger
+      @client.revoke!
+      expect(strio.string).to include("Received auth token response")
+    end
+
+    it "logs transient errors when they occur" do
+      allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::TimeoutError)
+      strio = StringIO.new
+      logger = Logger.new strio
+      @client.logger = logger
+      
+      # Stub sleep to avoid slow tests
+      allow(@client).to receive(:sleep)
+
+      expect { @client.revoke! }.to raise_error Signet::AuthorizationError
+      expect(strio.string).to include("Transient error when fetching auth token")
+      expect(strio.string).to include("Exhausted retries when fetching auth token")
+    end
+  end
+
   describe "when errors occurred with request" do
     it "should fail with Signet::AuthorizationError if request times out" do
       allow_any_instance_of(Faraday::Connection).to receive(:post)
         .and_raise(Faraday::TimeoutError)
+      expect(@client).to receive(:sleep).exactly(5).times.with(kind_of(Numeric))
       expect { @client.revoke! }
         .to raise_error Signet::AuthorizationError
     end
@@ -405,6 +441,7 @@ describe Google::Auth::UserRefreshCredentials do
     it "should fail with Signet::AuthorizationError if request fails" do
       allow_any_instance_of(Faraday::Connection).to receive(:post)
         .and_raise(Faraday::ConnectionFailed, nil)
+      expect(@client).to receive(:sleep).exactly(5).times.with(kind_of(Numeric))
       expect { @client.revoke! }
         .to raise_error Signet::AuthorizationError
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,10 @@ RSpec.configure do |config|
   config.include WebMock::API
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before(:each) do
+    allow(Google::Auth::CredentialsLoader).to receive(:load_gcloud_project_id).and_return("my-project-id")
+  end
 end
 
 module TestHelpers

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -18,6 +18,17 @@ require "webmock/minitest"
 
 require "googleauth"
 
+# Proactively stub the gcloud CLI call for all future Minitest tests
+module Google
+  module Auth
+    module CredentialsLoader
+      def load_gcloud_project_id
+        "my-project-id"
+      end
+    end
+  end
+end
+
 ##
 # A simple in-memory implementation of TokenStore
 # for UserAuthorizer initialization when testing


### PR DESCRIPTION
Fixes a bug in `UserRefreshCredentials.revoke!` where the method was returning an integer (0) instead of the response body, causing JSON parsing errors in `log_response`.

Fixes: https://github.com/googleapis/google-auth-library-ruby/issues/540