### PR TITLE
feat: port googleauth from multi_json to standard lib json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,7 @@ jobs:
         bundle install
     - name: Test ${{ matrix.task }}
       shell: bash
-      run: toys do ${{ matrix.task }} < /dev/null
+      run: |
+        for task in $(echo "${{ matrix.task }}" | tr ',' ' '); do
+          toys "$task" < /dev/null
+        done

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-env", "~> 2.2"
   gem.add_dependency "google-logging-utils", "~> 0.1"
   gem.add_dependency "jwt", ">= 1.4", "< 4.0"
-  gem.add_dependency "multi_json", "~> 1.11"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
   gem.add_dependency "signet", ">= 0.16", "< 2.a"
 

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-logging-utils", "~> 0.1"
   gem.add_dependency "jwt", ">= 1.4", "< 4.0"
   gem.add_dependency "os", ">= 0.9", "< 2.0"
+  gem.add_dependency "pstore", "~> 0.1"
   gem.add_dependency "signet", ">= 0.16", "< 2.a"
 
   if gem.respond_to? :metadata

--- a/lib/googleauth/client_id.rb
+++ b/lib/googleauth/client_id.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "multi_json"
+require "json"
 require "googleauth/credentials_loader"
 require "googleauth/errors"
 
@@ -85,7 +85,7 @@ module Google
         raise InitializationError, "File can not be nil." if file.nil?
         File.open file.to_s do |f|
           json = f.read
-          config = MultiJson.load json
+          config = JSON.parse json
           from_hash config
         end
       end

--- a/lib/googleauth/client_id.rb
+++ b/lib/googleauth/client_id.rb
@@ -85,7 +85,11 @@ module Google
         raise InitializationError, "File can not be nil." if file.nil?
         File.open file.to_s do |f|
           json = f.read
-          config = JSON.parse json
+          begin
+            config = JSON.parse json
+          rescue JSON::ParserError => e
+            raise InitializationError, "Invalid Client ID JSON file: #{e.message}"
+          end
           from_hash config
         end
       end

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -16,7 +16,6 @@ require "forwardable"
 require "json"
 require "pathname"
 require "signet/oauth_2/client"
-require "multi_json"
 
 require "googleauth/credentials_loader"
 require "googleauth/errors"
@@ -514,7 +513,7 @@ module Google
         json_key, clz = Google::Auth::DefaultCredentials.determine_creds_class creds_input[:json_key_io]
 
         # Re-serialize the parsed JSON and replace the IO stream in creds_input
-        creds_input[:json_key_io] = StringIO.new MultiJson.dump(json_key)
+        creds_input[:json_key_io] = StringIO.new JSON.generate(json_key)
 
         client = clz.make_creds creds_input
         options = options.select { |k, _v| k == :logger }
@@ -531,7 +530,7 @@ module Google
         json_key, clz = Google::Auth::DefaultCredentials.determine_creds_class io
 
         # Re-serialize the parsed JSON and create a new IO stream.
-        new_io = StringIO.new MultiJson.dump(json_key)
+        new_io = StringIO.new JSON.generate(json_key)
 
         clz.make_creds options.merge!(json_key_io: new_io)
       end

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -166,7 +166,11 @@ module Google
       # @param expected_type [String] The expected credential type name.
       # @raise [Google::Auth::InitializationError] If the JSON key type does not match the expected type.
       def load_and_verify_json_key_type json_key_io, expected_type
-        json_key = JSON.parse json_key_io.read
+        begin
+          json_key = JSON.parse json_key_io.read
+        rescue JSON::ParserError => e
+          raise Google::Auth::InitializationError, "Invalid JSON keyfile format: #{e.message}"
+        end
         json_key_io.rewind # Rewind the stream so it can be read again.
         return if json_key["type"] == expected_type
         raise Google::Auth::InitializationError,

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -14,6 +14,7 @@
 
 require "os"
 require "rbconfig"
+require "json"
 
 require "googleauth/errors"
 
@@ -152,7 +153,7 @@ module Google
         gcloud = GCLOUD_WINDOWS_COMMAND if OS.windows?
         gcloud = GCLOUD_POSIX_COMMAND unless OS.windows?
         gcloud_json = IO.popen("#{gcloud} #{GCLOUD_CONFIG_COMMAND}", err: :close, &:read)
-        config = MultiJson.load gcloud_json
+        config = JSON.parse gcloud_json
         config["configuration"]["properties"]["core"]["project"]
       rescue StandardError
         nil
@@ -165,7 +166,7 @@ module Google
       # @param expected_type [String] The expected credential type name.
       # @raise [Google::Auth::InitializationError] If the JSON key type does not match the expected type.
       def load_and_verify_json_key_type json_key_io, expected_type
-        json_key = MultiJson.load json_key_io.read
+        json_key = JSON.parse json_key_io.read
         json_key_io.rewind # Rewind the stream so it can be read again.
         return if json_key["type"] == expected_type
         raise Google::Auth::InitializationError,

--- a/lib/googleauth/default_credentials.rb
+++ b/lib/googleauth/default_credentials.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "multi_json"
+require "json"
 require "stringio"
 
 require "googleauth/credentials_loader"
@@ -81,7 +81,7 @@ module Google
         json_key_io = options[:json_key_io]
         json_key, clz = determine_creds_class json_key_io
         if json_key
-          io = StringIO.new MultiJson.dump(json_key)
+          io = StringIO.new JSON.generate(json_key)
           clz.make_creds options.merge(json_key_io: io)
         else
           clz.make_creds options
@@ -97,7 +97,7 @@ module Google
       #   or if the environment variable is undefined or unsupported.
       def self.determine_creds_class json_key_io = nil
         if json_key_io
-          json_key = MultiJson.load json_key_io.read
+          json_key = JSON.parse json_key_io.read
           key = "type"
           raise InitializationError, "the json is missing the '#{key}' field" unless json_key.key? key
           type = json_key[key]

--- a/lib/googleauth/external_account.rb
+++ b/lib/googleauth/external_account.rb
@@ -14,6 +14,7 @@
 
 require "time"
 require "uri"
+require "json"
 require "googleauth/credentials_loader"
 require "googleauth/errors"
 require "googleauth/external_account/aws_credentials"
@@ -62,12 +63,12 @@ module Google
           json_key_io, scope = options.values_at :json_key_io, :scope
 
           raise InitializationError, "A json file is required for external account credentials." unless json_key_io
-          json_key = MultiJson.load json_key_io.read, symbolize_keys: true
+          json_key = JSON.parse json_key_io.read, symbolize_names: true
           if json_key.key? :type
             json_key_io.rewind
           else # Defaults to class credential 'type' if missing.
             json_key[:type] = CREDENTIAL_TYPE_NAME
-            json_key_io = StringIO.new MultiJson.dump(json_key)
+            json_key_io = StringIO.new JSON.generate(json_key)
           end
           CredentialsLoader.load_and_verify_json_key_type json_key_io, CREDENTIAL_TYPE_NAME
           user_creds = read_json_key json_key_io
@@ -86,7 +87,7 @@ module Google
         # @return [Hash] The parsed JSON key
         # @raise [Google::Auth::InitializationError] If the JSON is missing required fields
         def self.read_json_key json_key_io
-          json_key = MultiJson.load json_key_io.read, symbolize_keys: true
+          json_key = JSON.parse json_key_io.read, symbolize_names: true
           wanted = [
             :audience, :subject_token_type, :token_url, :credential_source
           ]

--- a/lib/googleauth/external_account/aws_credentials.rb
+++ b/lib/googleauth/external_account/aws_credentials.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "time"
+require "json"
 require "googleauth/errors"
 require "googleauth/external_account/base_credentials"
 require "googleauth/external_account/external_account_utils"
@@ -226,7 +227,7 @@ module Google
         # Retrieves the AWS security credentials required for signing AWS requests from the AWS metadata server.
         def fetch_metadata_security_credentials role_name
           response = get_aws_resource "#{@credential_verification_url}/#{role_name}", "credentials"
-          MultiJson.load response.body
+          JSON.parse response.body
         end
 
         # Reads the name of the AWS region from the environment

--- a/lib/googleauth/external_account/base_credentials.rb
+++ b/lib/googleauth/external_account/base_credentials.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.require "time"
 
+require "json"
 require "googleauth/base_client"
 require "googleauth/errors"
 require "googleauth/helpers/connection"
@@ -190,7 +191,7 @@ module Google
           response = connection.post @service_account_impersonation_url do |req|
             req.headers["Authorization"] = "Bearer #{token}"
             req.headers["Content-Type"] = "application/json"
-            req.body = MultiJson.dump({ scope: @scope })
+            req.body = JSON.generate({ scope: @scope })
           end
 
           if response.status != 200
@@ -201,7 +202,7 @@ module Google
             )
           end
 
-          MultiJson.load response.body
+          JSON.parse response.body
         end
 
         def log_impersonated_token_request original_token

--- a/lib/googleauth/external_account/external_account_utils.rb
+++ b/lib/googleauth/external_account/external_account_utils.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.require "time"
 
+require "json"
 require "googleauth/base_client"
 require "googleauth/errors"
 require "googleauth/helpers/connection"
@@ -54,7 +55,7 @@ module Google
           end
 
           if response.status == 200
-            response_data = MultiJson.load response.body, symbolize_names: true
+            response_data = JSON.parse response.body, symbolize_names: true
             @project_id = response_data[:projectId]
           end
 

--- a/lib/googleauth/external_account/identity_pool_credentials.rb
+++ b/lib/googleauth/external_account/identity_pool_credentials.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "time"
+require "json"
 require "googleauth/errors"
 require "googleauth/external_account/base_credentials"
 require "googleauth/external_account/external_account_utils"
@@ -63,7 +64,7 @@ module Google
             token = content
           else
             begin
-              response_data = MultiJson.load content, symbolize_keys: true
+              response_data = JSON.parse content, symbolize_names: true
               token = response_data[@credential_source_field_name.to_sym]
             rescue StandardError
               raise CredentialsError, "Unable to parse subject_token from JSON resource #{resource_name} " \

--- a/lib/googleauth/external_account/pluggable_credentials.rb
+++ b/lib/googleauth/external_account/pluggable_credentials.rb
@@ -14,6 +14,7 @@
 
 require "open3"
 require "time"
+require "json"
 require "googleauth/errors"
 require "googleauth/external_account/base_credentials"
 require "googleauth/external_account/external_account_utils"
@@ -88,7 +89,7 @@ module Google
           env = inject_environment_variables
           output = subprocess_with_timeout env, @credential_source_executable_command,
                                            @credential_source_executable_timeout_millis
-          response = MultiJson.load output, symbolize_keys: true
+          response = JSON.parse output, symbolize_names: true
           parse_subject_token response
         end
 
@@ -99,7 +100,7 @@ module Google
           return nil unless File.exist? @credential_source_executable_output_file
           begin
             content = File.read @credential_source_executable_output_file, encoding: "utf-8"
-            response = MultiJson.load content, symbolize_keys: true
+            response = JSON.parse content, symbolize_names: true
           rescue StandardError
             return nil
           end

--- a/lib/googleauth/iam.rb
+++ b/lib/googleauth/iam.rb
@@ -14,7 +14,7 @@
 
 require "googleauth/signet"
 require "googleauth/credentials_loader"
-require "multi_json"
+require "json"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization

--- a/lib/googleauth/impersonated_service_account.rb
+++ b/lib/googleauth/impersonated_service_account.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "json"
 require "googleauth/base_client"
 require "googleauth/errors"
 require "googleauth/helpers/connection"
@@ -117,7 +118,7 @@ module Google
         end
 
         require "googleauth/default_credentials"
-        impersonated_json = MultiJson.load json_key_io.read
+        impersonated_json = JSON.parse json_key_io.read
         source_credentials_info = impersonated_json["source_credentials"]
 
         if source_credentials_info["type"] == CREDENTIAL_TYPE_NAME
@@ -127,7 +128,7 @@ module Google
         end
 
         source_credentials = DefaultCredentials.make_creds(
-          json_key_io: StringIO.new(MultiJson.dump(source_credentials_info))
+          json_key_io: StringIO.new(JSON.generate(source_credentials_info))
         )
 
         impersonation_url = impersonated_json["service_account_impersonation_url"]
@@ -279,7 +280,7 @@ module Google
 
         case resp.status
         when 200
-          response = MultiJson.load resp.body
+          response = JSON.parse resp.body
           self.expires_at = response["expireTime"]
           @access_token = response["accessToken"]
           access_token
@@ -310,7 +311,7 @@ module Google
         connection.post @impersonation_url do |req|
           req.headers.merge! auth_header
           req.headers["Content-Type"] = "application/json"
-          req.body = MultiJson.dump({ scope: @scope })
+          req.body = JSON.generate({ scope: @scope })
         end
       end
 

--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -30,7 +30,11 @@ module Google
       # @raise [Google::Auth::InitializationError] If client_email or private_key
       #   fields are missing from the JSON
       def read_json_key json_key_io
-        json_key = JSON.parse json_key_io.read
+        begin
+          json_key = JSON.parse json_key_io.read
+        rescue JSON::ParserError => e
+          raise InitializationError, "Invalid JSON keyfile format: #{e.message}"
+        end
         raise InitializationError, "missing client_email" unless json_key.key? "client_email"
         raise InitializationError, "missing private_key" unless json_key.key? "private_key"
         [

--- a/lib/googleauth/json_key_reader.rb
+++ b/lib/googleauth/json_key_reader.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "json"
 require "googleauth/errors"
 
 module Google
@@ -29,7 +30,7 @@ module Google
       # @raise [Google::Auth::InitializationError] If client_email or private_key
       #   fields are missing from the JSON
       def read_json_key json_key_io
-        json_key = MultiJson.load json_key_io.read
+        json_key = JSON.parse json_key_io.read
         raise InitializationError, "missing client_email" unless json_key.key? "client_email"
         raise InitializationError, "missing private_key" unless json_key.key? "private_key"
         [

--- a/lib/googleauth/oauth2/sts_client.rb
+++ b/lib/googleauth/oauth2/sts_client.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "json"
 require "googleauth/errors"
 require "googleauth/helpers/connection"
 
@@ -89,7 +90,7 @@ module Google
             raise AuthorizationError, "Token exchange failed with status #{response.status}"
           end
 
-          MultiJson.load response.body
+          JSON.parse response.body
         end
 
         private
@@ -104,7 +105,7 @@ module Google
             subject_token_type: options[:subject_token_type]
           }
           unless options[:additional_options].nil?
-            request_body[:options] = CGI.escape MultiJson.dump(options[:additional_options], symbolize_name: true)
+            request_body[:options] = CGI.escape JSON.generate(options[:additional_options])
           end
           request_body
         end

--- a/lib/googleauth/scope_util.rb
+++ b/lib/googleauth/scope_util.rb
@@ -14,7 +14,7 @@
 
 require "googleauth/signet"
 require "googleauth/credentials_loader"
-require "multi_json"
+require "json"
 
 module Google
   module Auth

--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 require "jwt"
-require "multi_json"
+require "json"
 require "stringio"
 
 require "google/logging/message"
@@ -66,12 +66,12 @@ module Google
 
         private_key, client_email, project_id, quota_project_id, universe_domain =
           if json_key_io
-            json_key = MultiJson.load json_key_io.read
+            json_key = JSON.parse json_key_io.read
             if json_key.key? "type"
               json_key_io.rewind
             else # Defaults to class credential 'type' if missing.
               json_key["type"] = CREDENTIAL_TYPE_NAME
-              json_key_io = StringIO.new MultiJson.dump(json_key)
+              json_key_io = StringIO.new JSON.generate(json_key)
             end
             CredentialsLoader.load_and_verify_json_key_type json_key_io, CREDENTIAL_TYPE_NAME
             read_json_key json_key_io

--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 require "uri"
-require "multi_json"
+require "json"
 require "googleauth/signet"
 require "googleauth/user_refresh"
 require "securerandom"
@@ -140,7 +140,7 @@ module Google
       def get_credentials user_id, scope = nil
         saved_token = stored_token user_id
         return nil if saved_token.nil?
-        data = MultiJson.load saved_token
+        data = JSON.parse saved_token
 
         if data.fetch("client_id", @client_id.id) != @client_id.id
           raise CredentialsError.with_details(
@@ -250,7 +250,7 @@ module Google
       # @return [Google::Auth::UserRefreshCredentials]
       #  The stored credentials
       def store_credentials user_id, credentials
-        json = MultiJson.dump(
+        json = JSON.generate(
           client_id:              credentials.client_id,
           access_token:           credentials.access_token,
           refresh_token:          credentials.refresh_token,

--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -16,7 +16,7 @@ require "googleauth/credentials_loader"
 require "googleauth/errors"
 require "googleauth/scope_util"
 require "googleauth/signet"
-require "multi_json"
+require "json"
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -50,12 +50,12 @@ module Google
       def self.make_creds options = {} # rubocop:disable Metrics/MethodLength
         json_key_io, scope = options.values_at :json_key_io, :scope
         user_creds = if json_key_io
-                       json_key = MultiJson.load json_key_io.read
+                       json_key = JSON.parse json_key_io.read
                        if json_key.key? "type"
                          json_key_io.rewind
                        else # Defaults to class credential 'type' if missing.
                          json_key["type"] = CREDENTIAL_TYPE_NAME
-                         json_key_io = StringIO.new MultiJson.dump(json_key)
+                         json_key_io = StringIO.new JSON.generate(json_key)
                        end
                        CredentialsLoader.load_and_verify_json_key_type json_key_io, CREDENTIAL_TYPE_NAME
                        read_json_key json_key_io
@@ -86,7 +86,7 @@ module Google
       # @return [Hash] The parsed JSON key
       # @raise [Google::Auth::InitializationError] If the JSON is missing required fields
       def self.read_json_key json_key_io
-        json_key = MultiJson.load json_key_io.read
+        json_key = JSON.parse json_key_io.read
         wanted = ["client_id", "client_secret", "refresh_token"]
         wanted.each do |key|
           raise InitializationError, "the json is missing the #{key} field" unless json_key.key? key

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "multi_json"
+require "json"
 require "googleauth/errors"
 require "googleauth/signet"
 require "googleauth/user_authorizer"
@@ -84,7 +84,7 @@ module Google
       #  Redirect URI if successfully extracted, nil otherwise
       def self.handle_auth_callback_deferred request
         callback_state, redirect_uri = extract_callback_state request
-        request.session[CALLBACK_STATE_KEY] = MultiJson.dump callback_state
+        request.session[CALLBACK_STATE_KEY] = JSON.generate callback_state
         redirect_uri
       end
 
@@ -166,7 +166,7 @@ module Google
 
         redirect_to = options[:redirect_to] || request.url
         request.session[XSRF_KEY] = SecureRandom.base64
-        options[:state] = MultiJson.dump(state.merge(
+        options[:state] = JSON.generate(state.merge(
                                            SESSION_ID_KEY  => request.session[XSRF_KEY],
                                            CURRENT_URI_KEY => redirect_to
                                          ))
@@ -194,7 +194,7 @@ module Google
           # Note - in theory, no need to check required scope as this is
           # expected to be called immediately after a return from authorization
           state_json = request.session.delete CALLBACK_STATE_KEY
-          callback_state = MultiJson.load state_json
+          callback_state = JSON.parse state_json
           WebUserAuthorizer.validate_callback_state callback_state, request
           get_and_store_credentials_from_code(
             user_id:  user_id,
@@ -214,7 +214,7 @@ module Google
       # @return [Array<Hash, String>]
       #  Callback state and redirect URI
       def self.extract_callback_state request
-        state = MultiJson.load(request.params[STATE_PARAM] || "{}")
+        state = JSON.parse(request.params[STATE_PARAM] || "{}")
         redirect_uri = state[CURRENT_URI_KEY]
         callback_state = {
           AUTH_CODE_KEY  => request.params[AUTH_CODE_KEY],

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -167,9 +167,9 @@ module Google
         redirect_to = options[:redirect_to] || request.url
         request.session[XSRF_KEY] = SecureRandom.base64
         options[:state] = JSON.generate(state.merge(
-                                           SESSION_ID_KEY  => request.session[XSRF_KEY],
-                                           CURRENT_URI_KEY => redirect_to
-                                         ))
+                                          SESSION_ID_KEY  => request.session[XSRF_KEY],
+                                          CURRENT_URI_KEY => redirect_to
+                                        ))
         options[:base_url] = request.url
         super options
       end

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -48,7 +48,7 @@ describe Google::Auth::GCECredentials do
       universe_stub.to_return body: @universe_domain, status: 200, headers: {"Metadata-Flavor" => "Google" }
     end
     if opts[:access_token]
-      body = MultiJson.dump("access_token" => opts[:access_token],
+      body = JSON.generate("access_token" => opts[:access_token],
                             "token_type"   => "Bearer",
                             "expires_in"   => 3600)
 

--- a/spec/googleauth/credentials_spec.rb
+++ b/spec/googleauth/credentials_spec.rb
@@ -44,7 +44,7 @@ describe Google::Auth::Credentials, :private do
     else
       body_fields["access_token"] = access_token || "12345abcde"
     end
-    body = MultiJson.dump body_fields
+    body = JSON.generate body_fields
     uri ||= "https://oauth2.googleapis.com/token"
     stub_request(:post, uri)
       .to_return(body: body, status: 200, headers: { "Content-Type" => "application/json" })

--- a/spec/googleauth/external_account/aws_credentials_spec.rb
+++ b/spec/googleauth/external_account/aws_credentials_spec.rb
@@ -139,7 +139,7 @@ describe Google::Auth::ExternalAccount::AwsCredentials do
   let :security_credential_endpoint_success do
     return unless security_credential_url and aws_metadata_role_name
     security_credential_endpoint.to_return(
-      body: MultiJson.dump(aws_security_credentials_response))
+      body: JSON.generate(aws_security_credentials_response))
   end
 
   let :security_credential_endpoint_failure do
@@ -197,7 +197,7 @@ describe Google::Auth::ExternalAccount::AwsCredentials do
   def impersonation_endpoint_success access_token
     return unless access_token and service_account_impersonation_url
     impersonation_endpoint(access_token).to_return(
-      body: MultiJson.dump(google_token_impersonation_response.merge({
+      body: JSON.generate(google_token_impersonation_response.merge({
         accessToken: access_token
       }))
     )
@@ -214,7 +214,7 @@ describe Google::Auth::ExternalAccount::AwsCredentials do
 
   def google_cred_endpoint_success access_token
     google_cred_endpoint.to_return(
-      body: MultiJson.dump(google_token_response.merge({
+      body: JSON.generate(google_token_response.merge({
         "access_token" => access_token
       }))
     )

--- a/spec/googleauth/external_account/identity_pool_credentials_spec.rb
+++ b/spec/googleauth/external_account/identity_pool_credentials_spec.rb
@@ -220,7 +220,7 @@ describe Google::Auth::ExternalAccount::IdentityPoolCredentials do
           :credential_source => CREDENTIAL_SOURCE_JSON,
         },
         :file_exists => true,
-        :file_output => MultiJson.dump(SUCCESS_RESPONSE),
+        :file_output => JSON.generate(SUCCESS_RESPONSE),
         :expect_result => "ACCESS_TOKEN",
       },
       {
@@ -291,7 +291,7 @@ describe Google::Auth::ExternalAccount::IdentityPoolCredentials do
           :token_url => TOKEN_URL,
           :credential_source => CREDENTIAL_SOURCE_JSON_URL,
         },
-        :url_response => {"status": 200, "body": MultiJson.dump(SUCCESS_RESPONSE)},
+        :url_response => {"status": 200, "body": JSON.generate(SUCCESS_RESPONSE)},
         :expect_result => "ACCESS_TOKEN",
       },
       {
@@ -347,7 +347,7 @@ describe Google::Auth::ExternalAccount::IdentityPoolCredentials do
             'format': {'type': 'json', 'subject_token_field_name': 'access_token'},
           },
         },
-        :url_response => {"status": 200, "body": MultiJson.dump({
+        :url_response => {"status": 200, "body": JSON.generate({
           'issued_token_type': 'urn:ietf:params:oauth:token-type:access_token',
           'token_type': 'Bearer',
           'expires_in': 3600,

--- a/spec/googleauth/external_account/pluggable_credentials_spec.rb
+++ b/spec/googleauth/external_account/pluggable_credentials_spec.rb
@@ -228,7 +228,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
             }
           }
         },
-        :file_content => MultiJson.dump(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_ID_TOKEN),
+        :file_content => JSON.generate(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_ID_TOKEN),
         :expect_token => EXECUTABLE_OIDC_TOKEN
       },
       {
@@ -244,7 +244,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
             }
           }
         },
-        :file_content => MultiJson.dump(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_JWT),
+        :file_content => JSON.generate(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_JWT),
         :expect_token => EXECUTABLE_OIDC_TOKEN
       },
       {
@@ -260,7 +260,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
             }
           }
         },
-        :file_content => MultiJson.dump(EXECUTABLE_SUCCESSFUL_SAML_RESPONSE),
+        :file_content => JSON.generate(EXECUTABLE_SUCCESSFUL_SAML_RESPONSE),
         :expect_token => EXECUTABLE_SAML_TOKEN
       }
     ]
@@ -329,7 +329,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump({}),
+          :stdout => JSON.generate({}),
           :stderr => "",
           :exit_status => 0,
         },
@@ -348,7 +348,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump({:version => 1}),
+          :stdout => JSON.generate({:version => 1}),
           :stderr => "",
           :exit_status => 0
         },
@@ -367,7 +367,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump({:version => 1, :success => false}),
+          :stdout => JSON.generate({:version => 1, :success => false}),
           :stderr => "",
           :exit_status => 0
         },
@@ -386,7 +386,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump(EXECUTABLE_FAILED_RESPONSE),
+          :stdout => JSON.generate(EXECUTABLE_FAILED_RESPONSE),
           :stderr => "",
           :exit_status => 0
         },
@@ -405,7 +405,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           },
         },
         :executable_return => {
-          :stdout => MultiJson.dump({
+          :stdout => JSON.generate({
             :version => 1,
             :success => true,
             :token_type => "urn:ietf:params:oauth:token-type:id_token",
@@ -430,7 +430,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           },
         },
         :executable_return => {
-          :stdout => MultiJson.dump({
+          :stdout => JSON.generate({
             :version => 1,
             :success => true,
             :id_token => EXECUTABLE_OIDC_TOKEN,
@@ -472,7 +472,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_ID_TOKEN),
+          :stdout => JSON.generate(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_ID_TOKEN),
           :stderr => "",
           :exit_status => 0
         },
@@ -491,7 +491,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_JWT),
+          :stdout => JSON.generate(EXECUTABLE_SUCCESSFUL_OIDC_RESPONSE_JWT),
           :stderr => "",
           :exit_status => 0
         },
@@ -510,7 +510,7 @@ describe Google::Auth::ExternalAccount::PluggableAuthCredentials do
           }
         },
         :executable_return => {
-          :stdout => MultiJson.dump(EXECUTABLE_SUCCESSFUL_SAML_RESPONSE),
+          :stdout => JSON.generate(EXECUTABLE_SUCCESSFUL_SAML_RESPONSE),
           :stderr => "",
           :exit_status => 0
         },

--- a/spec/googleauth/external_account_spec.rb
+++ b/spec/googleauth/external_account_spec.rb
@@ -31,7 +31,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     end
 
     def load_file options
-      @tempfile.write(MultiJson.dump(options))
+      @tempfile.write(JSON.generate(options))
       @tempfile.rewind
       Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: @tempfile)
     end
@@ -132,7 +132,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should be able to make aws credentials' do
       f = Tempfile.new('aws')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           type: 'external_account',
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:aws:token-type:aws4_request',
@@ -155,7 +155,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should be able to make identity pool credentials' do
       f = Tempfile.new('file')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           type: 'external_account',
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
@@ -175,7 +175,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should be able to make pluggable auth credentials' do
       f = Tempfile.new('file')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           type: 'external_account',
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
@@ -206,7 +206,7 @@ describe Google::Auth::ExternalAccount::Credentials do
             credential_source: {},
           }
           creds.delete(field)
-          f.write(MultiJson.dump(creds))
+          f.write(JSON.generate(creds))
           f.rewind
           expect { Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: f) }.to raise_error(/the json is missing the #{field} field/)
         ensure
@@ -219,7 +219,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should raise an error for invalid credentials' do
       f = Tempfile.new('invalid')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           type: 'external_account',
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
@@ -244,7 +244,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should raise an error if the credential type is not external_account' do
       f = Tempfile.new('invalid_type')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           type: 'service_account',
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
@@ -263,7 +263,7 @@ describe Google::Auth::ExternalAccount::Credentials do
     it 'should succeed if the credential type is missing (uses default)' do
       f = Tempfile.new('missing_type')
       begin
-        f.write(MultiJson.dump({
+        f.write(JSON.generate({
           audience: '//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID',
           subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
           token_url: 'https://sts.googleapis.com/v1/token',

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -204,7 +204,7 @@ describe "#get_application_default" do
     end
 
     def cred_json_text
-      MultiJson.dump cred_json
+      JSON.generate cred_json
     end
 
     it_behaves_like "it can successfully load credentials"
@@ -222,7 +222,7 @@ describe "#get_application_default" do
     end
 
     def cred_json_text
-      MultiJson.dump cred_json
+      JSON.generate cred_json
     end
 
     it_behaves_like "it can successfully load credentials"
@@ -248,7 +248,7 @@ describe "#get_application_default" do
       Dir.mktmpdir do |dir|
         key_path = File.join dir, "my_cert_file"
         FileUtils.mkdir_p File.dirname(key_path)
-        File.write key_path, MultiJson.dump(cred_json)
+        File.write key_path, JSON.generate(cred_json)
         ENV[@var_name] = key_path
         creds = Google::Auth.get_application_default @scope, options
         expect(creds).to be_a(Google::Auth::ImpersonatedServiceAccountCredentials)
@@ -285,7 +285,7 @@ describe "#get_application_default" do
     end
 
     def cred_json_text
-      MultiJson.dump cred_json
+      JSON.generate cred_json
     end
 
     it "fails if the GOOGLE_APPLICATION_CREDENTIALS file contains the creds" do

--- a/spec/googleauth/impersonated_service_account_spec.rb
+++ b/spec/googleauth/impersonated_service_account_spec.rb
@@ -52,7 +52,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
 
       it "creates credentials with UserRefreshCredentials as source" do
         creds = Google::Auth::ImpersonatedServiceAccountCredentials.make_creds(
-          json_key_io: StringIO.new(MultiJson.dump(impersonated_json))
+          json_key_io: StringIO.new(JSON.generate(impersonated_json))
         )
 
         expect(creds).to be_a(Google::Auth::ImpersonatedServiceAccountCredentials)
@@ -67,7 +67,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
 
       it "creates credentials with ServiceAccountCredentials as source" do
         creds = Google::Auth::ImpersonatedServiceAccountCredentials.make_creds(
-          json_key_io: StringIO.new(MultiJson.dump(impersonated_json))
+          json_key_io: StringIO.new(JSON.generate(impersonated_json))
         )
 
         expect(creds).to be_a(Google::Auth::ImpersonatedServiceAccountCredentials)
@@ -92,7 +92,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
       it "raises a runtime error" do
         expect {
           Google::Auth::ImpersonatedServiceAccountCredentials.make_creds(
-            json_key_io: StringIO.new(MultiJson.dump(recursive_impersonated_json))
+            json_key_io: StringIO.new(JSON.generate(recursive_impersonated_json))
           )
         }.to raise_error(Google::Auth::InitializationError, /Source credentials can't be of type.*use delegates/)
       end
@@ -103,14 +103,14 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
 
       it "uses scope from JSON if not provided in options" do
         creds = Google::Auth::ImpersonatedServiceAccountCredentials.make_creds(
-          json_key_io: StringIO.new(MultiJson.dump(impersonated_json))
+          json_key_io: StringIO.new(JSON.generate(impersonated_json))
         )
         expect(creds.scope).to eq(["scope1"])
       end
 
       it "uses scope from options if provided" do
         creds = Google::Auth::ImpersonatedServiceAccountCredentials.make_creds(
-          json_key_io: StringIO.new(MultiJson.dump(impersonated_json)),
+          json_key_io: StringIO.new(JSON.generate(impersonated_json)),
           scope: ["scope2"]
         )
         expect(creds.scope).to eq(["scope2"])
@@ -124,7 +124,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
     body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
     body_fields["accessToken"] = opts[:access_token]
     body_fields["expireTime"] = opts[:expireTime]
-    body = MultiJson.dump body_fields
+    body = JSON.generate body_fields
     stub_request(:post, impersonation_url)
       .to_return(body:    body,
                    status:  opts[:status] || 200,

--- a/spec/googleauth/service_account_jwt_header_spec.rb
+++ b/spec/googleauth/service_account_jwt_header_spec.rb
@@ -55,7 +55,7 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
   end
 
   def cred_json_text
-    MultiJson.dump cred_json
+    JSON.generate cred_json
   end
 
   it_behaves_like "jwt header auth"

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -79,7 +79,7 @@ describe Google::Auth::ServiceAccountCredentials do
       else
         raise "Expected access_token or id_token"
       end
-    body = MultiJson.dump body_fields
+    body = JSON.generate body_fields
     blk = proc do |request|
       params = Addressable::URI.form_unencode request.body
       claim, _header = JWT.decode(params.assoc("assertion").last,
@@ -97,11 +97,11 @@ describe Google::Auth::ServiceAccountCredentials do
   end
 
   def cred_json_text
-    MultiJson.dump cred_json
+    JSON.generate cred_json
   end
 
   def cred_json_text_with_universe_domain
-    MultiJson.dump cred_json_with_universe_domain
+    JSON.generate cred_json_with_universe_domain
   end
 
   it_behaves_like "apply/apply! are OK"
@@ -110,7 +110,7 @@ describe Google::Auth::ServiceAccountCredentials do
     cred_json[:type] = "authorized_user"
     expect do
       ServiceAccountCredentials.make_creds(
-        json_key_io: StringIO.new(MultiJson.dump(cred_json))
+        json_key_io: StringIO.new(JSON.generate(cred_json))
       )
     end.to raise_error(
       Google::Auth::InitializationError,
@@ -123,7 +123,7 @@ describe Google::Auth::ServiceAccountCredentials do
     key_without_type = cred_json.reject { |k, _| k == :type }
     expect do
       ServiceAccountCredentials.make_creds(
-        json_key_io: StringIO.new(MultiJson.dump(key_without_type))
+        json_key_io: StringIO.new(JSON.generate(key_without_type))
       )
     end.not_to raise_error(
         Google::Auth::InitializationError, /The provided credentials were not of type 'service_account'/

--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -45,7 +45,7 @@ describe Signet::OAuth2::Client do
     body_fields = { "token_type" => "Bearer", "expires_in" => 3600 }
     body_fields["access_token"] = opts[:access_token] if opts[:access_token]
     body_fields["id_token"] = opts[:id_token] if opts[:id_token]
-    body = MultiJson.dump body_fields
+    body = JSON.generate body_fields
     blk = proc do |request|
       params = Addressable::URI.form_unencode request.body
       claim, _header = JWT.decode(params.assoc("assertion").last,

--- a/spec/googleauth/user_authorizer_spec.rb
+++ b/spec/googleauth/user_authorizer_spec.rb
@@ -204,7 +204,7 @@ describe Google::Auth::UserAuthorizer do
 
   context "when retrieving tokens" do
     let :token_json do
-      MultiJson.dump(
+      JSON.generate(
         access_token:           "accesstoken",
         refresh_token:          "refreshtoken",
         expiration_time_millis: 1_441_234_742_000
@@ -256,7 +256,7 @@ describe Google::Auth::UserAuthorizer do
     
     context "with mismatched client_id" do
       let :mismatched_token_json do
-        MultiJson.dump(
+        JSON.generate(
           client_id:              "mismatched_client_id",
           access_token:           "accesstoken",
           refresh_token:          "refreshtoken",
@@ -302,24 +302,24 @@ describe Google::Auth::UserAuthorizer do
     end
 
     it "should persist the refresh token" do
-      expect(MultiJson.load(token_json)["refresh_token"]).to eq "refreshtoken"
+      expect(JSON.parse(token_json)["refresh_token"]).to eq "refreshtoken"
     end
 
     it "should persist the access token" do
-      expect(MultiJson.load(token_json)["access_token"]).to eq "accesstoken"
+      expect(JSON.parse(token_json)["access_token"]).to eq "accesstoken"
     end
 
     it "should persist the client id" do
-      expect(MultiJson.load(token_json)["client_id"]).to eq "testclient"
+      expect(JSON.parse(token_json)["client_id"]).to eq "testclient"
     end
 
     it "should persist the scope" do
-      expect(MultiJson.load(token_json)["scope"]).to include("email", "profile")
+      expect(JSON.parse(token_json)["scope"]).to include("email", "profile")
     end
 
     it "should persist the expiry as milliseconds" do
       expected_expiry = expiry * 1000
-      expect(MultiJson.load(token_json)["expiration_time_millis"]).to eql(
+      expect(JSON.parse(token_json)["expiration_time_millis"]).to eql(
         expected_expiry
       )
     end
@@ -327,7 +327,7 @@ describe Google::Auth::UserAuthorizer do
 
   context "with valid authorization code" do
     let :token_json do
-      MultiJson.dump("access_token" => "1/abc123",
+      JSON.generate("access_token" => "1/abc123",
                      "token_type"   => "Bearer",
                      "expires_in"   => 3600)
     end
@@ -382,7 +382,7 @@ describe Google::Auth::UserAuthorizer do
 
   context "when reovking authorization" do
     let :token_json do
-      MultiJson.dump(
+      JSON.generate(
         access_token:           "accesstoken",
         refresh_token:          "refreshtoken",
         expiration_time_millis: 1_441_234_742_000

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -60,7 +60,7 @@ describe Google::Auth::UserRefreshCredentials do
 
   def make_auth_stubs opts
     access_token = opts[:access_token] || ""
-    body = MultiJson.dump("access_token" => access_token,
+    body = JSON.generate("access_token" => access_token,
                           "token_type"   => "Bearer",
                           "expires_in"   => 3600)
     stub_request(:post, "https://oauth2.googleapis.com/token")
@@ -72,12 +72,12 @@ describe Google::Auth::UserRefreshCredentials do
 
   def cred_json_text missing = nil
     cred_json.delete missing.to_sym unless missing.nil?
-    MultiJson.dump cred_json
+    JSON.generate cred_json
   end
 
   def cred_json_text_with_universe_domain missing = nil
     cred_json_with_universe_domain.delete missing.to_sym unless missing.nil?
-    MultiJson.dump cred_json_with_universe_domain
+    JSON.generate cred_json_with_universe_domain
   end
 
   it_behaves_like "apply/apply! are OK"
@@ -86,7 +86,7 @@ describe Google::Auth::UserRefreshCredentials do
     cred_json[:type] = "service_account"
     expect do
       UserRefreshCredentials.make_creds(
-        json_key_io: StringIO.new(MultiJson.dump(cred_json))
+        json_key_io: StringIO.new(JSON.generate(cred_json))
       )
     end.to raise_error(
       Google::Auth::InitializationError,
@@ -99,7 +99,7 @@ describe Google::Auth::UserRefreshCredentials do
     key_without_type = cred_json.reject { |k, _| k == :type }
     expect do
       UserRefreshCredentials.make_creds(
-        json_key_io: StringIO.new(MultiJson.dump(key_without_type))
+        json_key_io: StringIO.new(JSON.generate(key_without_type))
       )
     end.not_to raise_error(
         Google::Auth::InitializationError, /The provided credentials were not of type 'authorized_user'/

--- a/spec/googleauth/web_user_authorizer_spec.rb
+++ b/spec/googleauth/web_user_authorizer_spec.rb
@@ -115,7 +115,7 @@ describe Google::Auth::WebUserAuthorizer do
 
   shared_examples "handles callback" do
     let :token_json do
-      MultiJson.dump("access_token" => "1/abc123",
+      JSON.generate("access_token" => "1/abc123",
                      "token_type"   => "Bearer",
                      "expires_in"   => 3600)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,11 +25,8 @@ require "rspec"
 require "logging"
 require "rspec/logging_helper"
 require "webmock/rspec"
-require "multi_json"
 require "google/cloud/env"
 
-# Preload adapter to work around Rubinius error with FakeFS
-MultiJson.use :json_gem
 
 # Allow Faraday to support test stubs
 Faraday::Adapter.lookup_middleware :test

--- a/test/client_id_test.rb
+++ b/test/client_id_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "helper"
+require "json"
 require "fakefs/safe"
 
 describe Google::Auth::ClientId do
@@ -47,7 +48,7 @@ describe Google::Auth::ClientId do
           file_path = "/client_secrets.json"
           let :client_id do
             FakeFS do
-              content = MultiJson.dump config
+              content = JSON.generate config
               File.write file_path, content
               Google::Auth::ClientId.from_file file_path
             end

--- a/test/client_id_test.rb
+++ b/test/client_id_test.rb
@@ -134,4 +134,16 @@ describe Google::Auth::ClientId do
       assert_match(/Client secret can not be nil/, error.message)
     end
   end
+
+  describe "with malformed JSON file" do
+    it "should raise InitializationError" do
+      FakeFS do
+        File.write "/client_secrets.json", "{invalid_json"
+        error = assert_raises Google::Auth::InitializationError do
+          Google::Auth::ClientId.from_file "/client_secrets.json"
+        end
+        assert_match(/Invalid Client ID JSON file/, error.message)
+      end
+    end
+  end
 end

--- a/test/json_key_reader_test.rb
+++ b/test/json_key_reader_test.rb
@@ -15,7 +15,7 @@
 require_relative "helper"
 require "googleauth/json_key_reader"
 require "stringio"
-require "multi_json"
+require "json"
 
 class DummyKeyReader
   include Google::Auth::JsonKeyReader
@@ -34,7 +34,7 @@ describe Google::Auth::JsonKeyReader do
         "universe_domain" => "googleapis.com"
       }
       
-      json_key_io = StringIO.new(MultiJson.dump(json_key_hash))
+      json_key_io = StringIO.new(JSON.generate(json_key_hash))
       
       private_key, client_email, project_id, quota_project_id, universe_domain = 
         dummy_reader.read_json_key(json_key_io)
@@ -51,7 +51,7 @@ describe Google::Auth::JsonKeyReader do
         "private_key" => "dummy-key"
       }
       
-      json_key_io = StringIO.new(MultiJson.dump(json_key_hash))
+      json_key_io = StringIO.new(JSON.generate(json_key_hash))
       
       error = assert_raises Google::Auth::InitializationError do
         dummy_reader.read_json_key(json_key_io)
@@ -65,7 +65,7 @@ describe Google::Auth::JsonKeyReader do
         "client_email" => "dummy@example.com"
       }
       
-      json_key_io = StringIO.new(MultiJson.dump(json_key_hash))
+      json_key_io = StringIO.new(JSON.generate(json_key_hash))
       
       error = assert_raises Google::Auth::InitializationError do
         dummy_reader.read_json_key(json_key_io)

--- a/test/json_key_reader_test.rb
+++ b/test/json_key_reader_test.rb
@@ -73,5 +73,15 @@ describe Google::Auth::JsonKeyReader do
       
       _(error.message).must_equal "missing private_key"
     end
+
+    it "raises InitializationError when JSON format is invalid" do
+      json_key_io = StringIO.new("{invalid-json")
+      
+      error = assert_raises Google::Auth::InitializationError do
+        dummy_reader.read_json_key(json_key_io)
+      end
+      
+      assert_match(/Invalid JSON keyfile format/, error.message)
+    end
   end
 end

--- a/test/principal_test.rb
+++ b/test/principal_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 require "stringio"
-require "multi_json"
+require "json"
 
 require "googleauth/api_key"
 require "googleauth/bearer_token"
@@ -67,7 +67,7 @@ describe "Principal methods" do
         client_email: test_email,
         type:         "service_account"
       }
-      key_io = StringIO.new MultiJson.dump(json)
+      key_io = StringIO.new JSON.generate(json)
       creds = Google::Auth::ServiceAccountCredentials.make_creds json_key_io: key_io
       _(creds.principal).must_equal test_email
     end
@@ -80,7 +80,7 @@ describe "Principal methods" do
         private_key:  @key = OpenSSL::PKey::RSA.new(2048).to_pem,
         client_email: test_email
       }
-      key_io = StringIO.new MultiJson.dump(json)
+      key_io = StringIO.new JSON.generate(json)
       creds = Google::Auth::ServiceAccountJwtHeaderCredentials.make_creds json_key_io: key_io
       _(creds.principal).must_equal test_email
     end
@@ -133,7 +133,7 @@ describe "Principal methods" do
         refresh_token: "refreshing-token",
         type:          "authorized_user"
       }
-      key_io = StringIO.new MultiJson.dump(json)
+      key_io = StringIO.new JSON.generate(json)
       creds = Google::Auth::UserRefreshCredentials.make_creds json_key_io: key_io
       _(creds.principal).must_equal test_client_id
     end


### PR DESCRIPTION
* googleauth is now guaranteed to use the standard library JSON engine
  natively, providing absolute consistency regardless of user configurations.
* Remove multi_json's possible dispatch overhead and lock/mutex contention.
* Slightly reduce overall memory footprint per request.
* Add pstore to gemspec for Ruby 4.0 compatibility.
* Tests under multi_json already enforced the use of the json gem.
* Wrap JSON::ParserError in Google::Auth::InitializationError at main entry points.

fixes: #572