### PR TITLE
test(auth): enforce strict once call counts on token caching tests

### DIFF
--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -42,7 +42,7 @@ shared_examples "apply/apply! are OK" do
       access_stub
       @client.fetch_access_token!
       expect(@client.access_token).to eq(token)
-      expect(access_stub).to have_been_requested
+      expect(access_stub).to have_been_requested.once
     end
 
     it "should set id_token to the fetched value" do
@@ -50,7 +50,7 @@ shared_examples "apply/apply! are OK" do
       id_stub
       @id_client.fetch_access_token!
       expect(@id_client.id_token).to eq(token)
-      expect(id_stub).to have_been_requested
+      expect(id_stub).to have_been_requested.once
     end
 
     it "should notify refresh listeners after updating" do
@@ -61,7 +61,7 @@ shared_examples "apply/apply! are OK" do
       end.to yield_with_args(have_attributes(
                                access_token: "1/abcdef1234567890"
                              ))
-      expect(access_stub).to have_been_requested
+      expect(access_stub).to have_been_requested.once
     end
 
     it "should log when a logger is set" do
@@ -94,7 +94,7 @@ shared_examples "apply/apply! are OK" do
       @client.apply! md
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(md).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should update the target hash with fetched ID token" do
@@ -106,7 +106,7 @@ shared_examples "apply/apply! are OK" do
       @id_client.apply! md
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(md).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
   end
 
@@ -119,7 +119,7 @@ shared_examples "apply/apply! are OK" do
       got = the_proc.call md
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
   end
 
@@ -132,7 +132,7 @@ shared_examples "apply/apply! are OK" do
       @client.apply md
       want = { foo: "bar" }
       expect(md).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should add the token to the returned hash" do
@@ -143,7 +143,7 @@ shared_examples "apply/apply! are OK" do
       got = @client.apply md
       want = { :foo => "bar", auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should not fetch a new token if the current is not expired" do
@@ -157,7 +157,7 @@ shared_examples "apply/apply! are OK" do
         want = { :foo => "bar", auth_key => "Bearer #{token}" }
         expect(got).to eq(want)
       end
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should fetch a new token if the current one is expired" do

--- a/spec/googleauth/compute_engine_spec.rb
+++ b/spec/googleauth/compute_engine_spec.rb
@@ -195,7 +195,7 @@ describe Google::Auth::GCECredentials do
         stub = make_auth_stubs access_token: "1/abcdef1234567890", scope: scopes
         @client = GCECredentials.new(scope: scopes)
         @client.fetch_access_token!
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
     end
 
@@ -220,7 +220,7 @@ describe Google::Auth::GCECredentials do
         token = "#{Base64.urlsafe_encode64 JSON.dump header}.#{Base64.urlsafe_encode64 JSON.dump payload}.xxxxx"
         stub = make_auth_stubs id_token: token
         @id_client.fetch_access_token!
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
         expect(@id_client.expires_at.to_i).to eq(expiry_time)
       end
     end
@@ -234,7 +234,7 @@ describe Google::Auth::GCECredentials do
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @client.fetch_access_token! }
           .to raise_error Signet::AuthorizationError
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
 
       it "should fail if the metadata request returns a 403" do
@@ -261,7 +261,7 @@ describe Google::Auth::GCECredentials do
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @client.fetch_access_token! }
           .to raise_error Signet::AuthorizationError
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
 
       it "should fail with AuthorizationError including detailed error info on timeout" do
@@ -300,7 +300,7 @@ describe Google::Auth::GCECredentials do
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @id_client.fetch_access_token! }
           .to raise_error Signet::AuthorizationError
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
 
       it "should fail if the metadata request returns a 403" do
@@ -327,7 +327,7 @@ describe Google::Auth::GCECredentials do
                           headers: { "Metadata-Flavor" => "Google" })
         expect { @id_client.fetch_access_token! }
           .to raise_error Signet::AuthorizationError
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
 
       it "should fail with Signet::AuthorizationError if request times out" do
@@ -353,7 +353,7 @@ describe Google::Auth::GCECredentials do
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(true)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should be false when Metadata-Flavor is not Google" do
@@ -362,7 +362,7 @@ describe Google::Auth::GCECredentials do
              .to_return(status:  200,
                         headers: { "Metadata-Flavor" => "NotGoogle" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should be false if the response is not 200" do
@@ -371,7 +371,7 @@ describe Google::Auth::GCECredentials do
              .to_return(status:  404,
                         headers: { "Metadata-Flavor" => "Google" })
       expect(GCECredentials.on_gce?({}, true)).to eq(false)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "should honor GCE_METADATA_HOST environment variable" do
@@ -383,7 +383,7 @@ describe Google::Auth::GCECredentials do
                .to_return(status:  200,
                           headers: { "Metadata-Flavor" => "Google" })
         expect(GCECredentials.on_gce?({}, true)).to eq(true)
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       ensure
         ENV.delete "GCE_METADATA_HOST"
         Google::Cloud.env.compute_metadata.reset!

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -146,7 +146,7 @@ describe "#get_application_default" do
           creds = Google::Auth.get_application_default @scope, options
           expect(creds).to_not be_nil
         end
-        expect(@compute_metadata_server).to have_been_requested
+        expect(@compute_metadata_server).to have_been_requested.once
       end
 
       it "honors passing options to OAuth 2 client" do
@@ -161,7 +161,7 @@ describe "#get_application_default" do
           expect(creds).to be gce_credentials
           expect(GCECredentials).to have_received(:new).with(options.merge(scope: @scope))
         end
-        expect(@compute_metadata_server).to have_been_requested
+        expect(@compute_metadata_server).to have_been_requested.once
       end
     end
 

--- a/spec/googleauth/impersonated_service_account_spec.rb
+++ b/spec/googleauth/impersonated_service_account_spec.rb
@@ -234,7 +234,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
       hash = {}
       creds.apply!(hash)
       
-      expect(@stub).to have_been_requested
+      expect(@stub).to have_been_requested.once
       expect(hash[Google::Auth::ImpersonatedServiceAccountCredentials::AUTH_METADATA_KEY]).to eq("Bearer 1/abcde")
     end
 
@@ -327,7 +327,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
           expect(error.principal).to eq("test-principal")
         end
         
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
     end
 
@@ -342,7 +342,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
           expect(error.principal).to eq("test-principal")
         end
         
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
     end
 
@@ -357,7 +357,7 @@ describe Google::Auth::ImpersonatedServiceAccountCredentials do
           expect(error.principal).to eq("test-principal")
         end
         
-        expect(stub).to have_been_requested
+        expect(stub).to have_been_requested.once
       end
     end
   end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -201,7 +201,7 @@ describe Google::Auth::ServiceAccountCredentials do
       id_token = "#{Base64.urlsafe_encode64 JSON.dump header}.#{Base64.urlsafe_encode64 JSON.dump payload}.xxxxx"
       stub = make_auth_stubs id_token: id_token
       @id_client.fetch_access_token!
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
       expect(@id_client.id_token).to eq(id_token)
       expect(@id_client.expires_at.to_i).to eq(expiry_time)
     end

--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -76,7 +76,7 @@ describe Signet::OAuth2::Client do
       @client.apply! md
       want = { foo: "bar", authorization: "Bearer #{token}" }
       expect(md).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
 
     it "honors connection_builder" do
@@ -90,7 +90,7 @@ describe Signet::OAuth2::Client do
       @client.apply! md
       want = { foo: "bar", authorization: "Bearer #{token}" }
       expect(md).to eq(want)
-      expect(stub).to have_been_requested
+      expect(stub).to have_been_requested.once
     end
   end
 


### PR DESCRIPTION
The Ruby specs relied on loose have_been_requested expectations which only check if a request happened, not how many times. Other languages (like Python, Swift, and Java) verify caching logic by asserting that exactly one outbound HTTP request is made regardless of the number of credential calls.