### PR TITLE
test(auth): verify APPDATA fallback for well-known file on Windows

### DIFF
--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -120,6 +120,23 @@ describe "#get_application_default" do
       end
     end
 
+    it "succeeds with default file on Windows when OS.windows? is mocked to true" do
+      # Verify that when operating on a Windows system, the ADC loader properly resolves
+      # the well-known credentials file from the APPDATA environment variable rather than HOME.
+      allow(OS).to receive(:windows?).and_return(true)
+      ENV.delete @var_name unless ENV[@var_name].nil?
+      Dir.mktmpdir do |dir|
+        key_path = File.join dir, WELL_KNOWN_PATH
+        FileUtils.mkdir_p File.dirname(key_path)
+        File.write key_path, cred_json_text
+        ENV["APPDATA"] = dir
+        ENV["HOME"] = nil
+        expect(Google::Auth.get_application_default(@scope, options))
+          .to_not be_nil
+      end
+    end
+
+
     it "succeeds with default file without a scope" do
       ENV.delete @var_name unless ENV[@var_name].nil?
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
Adds a test case explicitly mocking the `OS.windows?` check to guarantee that Windows `APPDATA` fallback resolves correctly and is fully covered under CI execution on any platform.

Other correct languages (such as Python, Node.js, and Go) consistently test their Windows configuration directories independently of the CI host environment. Adding this explicit test ensures Ruby maintains verifiable parity with the standard Windows fallback resolution sequence.