### PR TITLE
chore(actions): fix setup-ruby action version comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install NodeJS 18.x


### PR DESCRIPTION
This fixes the version tag comment for setup-ruby to be `v1.314.0` instead of `v1` to match the SHA.