### PR TITLE
fix(auth): validate options parameter in ServiceAccountCredentials.make_creds

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -45,6 +45,19 @@ module Google
       # @type [::String] The type name for this credential.
       CREDENTIAL_TYPE_NAME = "service_account".freeze
 
+      # @private
+      # @type [Array<Symbol>] Allowed option keys for make_creds.
+      VALID_MAKE_CREDS_OPTIONS = [
+        :json_key_io,
+        :scope,
+        :enable_self_signed_jwt,
+        :target_audience,
+        :audience,
+        :token_credential_uri,
+        :default_connection,
+        :connection_builder
+      ].freeze
+
       def enable_self_signed_jwt?
         # Use a self-singed JWT if there's no information that can be used to
         # obtain an OAuth token, OR if there are scopes but also an assertion
@@ -55,10 +68,20 @@ module Google
 
       # Creates a ServiceAccountCredentials.
       #
-      # @param json_key_io [IO] An IO object containing the JSON key
-      # @param scope [string|array|nil] the scope(s) to access
+      # @param json_key_io [IO, nil] Optional. An IO object containing the JSON key
+      # @param scope [String, Array<String>, nil] Optional. The scope(s) to access
+      # @param enable_self_signed_jwt [Boolean, nil] Optional. Whether to use self-signed JWTs
+      # @param target_audience [String, nil] Optional. The target audience for ID token requests
+      # @param audience [String, nil] Optional. Custom token endpoint audience URI
+      # @param token_credential_uri [String, nil] Optional. Custom token credential URI
+      # @param default_connection [Faraday::Connection, nil] Optional. The connection object to use
+      # @param connection_builder [Proc, nil] Optional. A Proc that returns a Faraday connection
       # @raise [ArgumentError] If both scope and target_audience are specified
+      # @raise [InitializationError] If json_key_io is not an IO object, or
+      #   if required credential fields (private_key or client_email) are missing
       def self.make_creds options = {} # rubocop:disable Metrics/MethodLength
+        validate_make_creds_options options
+
         json_key_io, scope, enable_self_signed_jwt, target_audience, audience, token_credential_uri =
           options.values_at :json_key_io, :scope, :enable_self_signed_jwt, :target_audience,
                             :audience, :token_credential_uri
@@ -66,6 +89,9 @@ module Google
 
         private_key, client_email, project_id, quota_project_id, universe_domain =
           if json_key_io
+            unless json_key_io.respond_to? :read
+              raise InitializationError, "Expected an IO object for json_key_io"
+            end
             json_key = JSON.parse json_key_io.read
             if json_key.key? "type"
               json_key_io.rewind
@@ -78,6 +104,10 @@ module Google
           else
             creds_from_env
           end
+
+        raise InitializationError, "Missing required field: private_key" unless private_key
+        raise InitializationError, "Missing required field: client_email" unless client_email
+
         project_id ||= CredentialsLoader.load_gcloud_project_id
 
         new(token_credential_uri:   token_credential_uri || TOKEN_CRED_URI,
@@ -122,8 +152,9 @@ module Google
       # enclosing quotes.
       #
       # @param str [String] The string to unescape
-      # @return [String] The unescaped string
+      # @return [String, nil] The unescaped string, or nil if input is nil
       def self.unescape str
+        return nil unless str
         str = str.gsub '\n', "\n"
         str = str[1..-2] if str.start_with?('"') && str.end_with?('"')
         str
@@ -212,7 +243,20 @@ module Google
         [private_key, client_email, project_id, nil, nil]
       end
 
-      private_class_method :creds_from_env
+      # @private
+      # Validates options passed to make_creds and emits a warning for unrecognized keys.
+      #
+      # @param options [Hash] The options hash to validate.
+      def self.validate_make_creds_options options
+        return unless options.is_a? Hash
+
+        unknown_keys = options.keys - VALID_MAKE_CREDS_OPTIONS
+        return if unknown_keys.empty?
+
+        warn "Unrecognized option(s) for ServiceAccountCredentials.make_creds: #{unknown_keys.map(&:inspect).join ', '}"
+      end
+
+      private_class_method :creds_from_env, :validate_make_creds_options
     end
   end
 end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -125,9 +125,51 @@ describe Google::Auth::ServiceAccountCredentials do
       ServiceAccountCredentials.make_creds(
         json_key_io: StringIO.new(JSON.generate(key_without_type))
       )
-    end.not_to raise_error(
-        Google::Auth::InitializationError, /The provided credentials were not of type 'service_account'/
-    )
+    end.not_to raise_error
+  end
+
+  it "raises InitializationError when credentials are missing" do
+    expect do
+      ServiceAccountCredentials.make_creds(
+        scope: "https://www.googleapis.com/auth/userinfo.profile"
+      )
+    end.to raise_error(Google::Auth::InitializationError, /Missing required field/)
+  end
+
+  it "raises InitializationError when json_key_io is passed a String instead of an IO object" do
+    expect do
+      ServiceAccountCredentials.make_creds(
+        json_key_io: cred_json_text
+      )
+    end.to raise_error(Google::Auth::InitializationError, "Expected an IO object for json_key_io")
+  end
+
+  it "warns when unrecognized options are provided" do
+    expect do
+      ServiceAccountCredentials.make_creds(
+        json_key_io: StringIO.new(cred_json_text),
+        scopes: ["https://www.googleapis.com/auth/userinfo.profile"]
+      )
+    end.to output(/Unrecognized option\(s\) for ServiceAccountCredentials\.make_creds: :scopes/).to_stderr
+  end
+
+  it "warns when string key option names are provided" do
+    expect do
+      ServiceAccountCredentials.make_creds(
+        json_key_io: StringIO.new(cred_json_text),
+        "scope" => ["https://www.googleapis.com/auth/userinfo.profile"]
+      )
+    end.to output(/Unrecognized option\(s\) for ServiceAccountCredentials\.make_creds: "scope"/).to_stderr
+  end
+
+  describe ".unescape" do
+    it "returns nil when given nil" do
+      expect(ServiceAccountCredentials.unescape(nil)).to be_nil
+    end
+
+    it "unescapes newlines and surrounding quotes" do
+      expect(ServiceAccountCredentials.unescape("\"line1\\nline2\"")).to eq("line1\nline2")
+    end
   end
 
   describe "universe_domain" do


### PR DESCRIPTION
- Warn on unrecognized options passed to `ServiceAccountCredentials.make_creds`.
- Raise `InitializationError` when required credential fields or valid `json_key_io` objects are missing.
- Fix `unescape(nil)` bug to handle `nil` inputs safely.
- Update `make_creds` docstring to document all supported options.

Fixes #482
Fixes #544
